### PR TITLE
fix: route __call__ through nn.Module to preserve hooks

### DIFF
--- a/torchebm/core/base_loss.py
+++ b/torchebm/core/base_loss.py
@@ -64,7 +64,8 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
 
     def __call__(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         """
-        Calls the forward method of the loss function.
+        Calls the loss function through nn.Module.__call__ to preserve hooks
+        and the full _call_impl machinery.
 
         Args:
             x (torch.Tensor): Input data tensor.
@@ -75,7 +76,7 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
             torch.Tensor: The computed loss value.
         """
         x = x.to(device=self.device, dtype=self.dtype)
-        return self.forward(x, *args, **kwargs)
+        return super().__call__(x, *args, **kwargs)
 
 
 class BaseContrastiveDivergence(BaseLoss):
@@ -489,7 +490,8 @@ class BaseScoreMatching(BaseLoss):
 
     def __call__(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         """
-        Calls the forward method of the loss function.
+        Calls the score matching loss through nn.Module.__call__ to preserve
+        hooks and the full _call_impl machinery.
 
         Args:
             x (torch.Tensor): Input data tensor.
@@ -501,7 +503,7 @@ class BaseScoreMatching(BaseLoss):
         """
 
         x = x.to(device=self.device, dtype=self.dtype)
-        return self.forward(x, *args, **kwargs)
+        return super().__call__(x, *args, **kwargs)
 
     @abstractmethod
     def forward(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:


### PR DESCRIPTION
## Summary

Both `BaseLoss.__call__` and `BaseScoreMatching.__call__` were calling `self.forward()` directly, bypassing `nn.Module._call_impl`. This meant PyTorch hooks (forward hooks, backward hooks, etc.) were silently skipped whenever a loss module was invoked.

## Changes

Changed both methods to call `super().__call__()` which goes through the standard `nn.Module.__call__` → `_call_impl` → `forward()` path, preserving all hook machinery while keeping the existing dtype/device conversion logic.

**Files modified:** `torchebm/core/base_loss.py`
- `BaseLoss.__call__` (line 78): `self.forward(...)` → `super().__call__(...)`
- `BaseScoreMatching.__call__` (line 506): `self.forward(...)` → `super().__call__(...)`

## Why this matters

`nn.Module._call_impl` is responsible for:
- Running registered forward pre-hooks and forward hooks
- Setting up `torch.autograd.grad_mode` correctly
- Calling `_slow_forward` for tracing compatibility
- Error handling for missing `forward()` implementations

By bypassing it, any user code that registers hooks on loss modules (e.g., for logging, gradient monitoring, debugging) would silently have those hooks ignored.

## How to test

```python
import torch
from torchebm.core import HarmonicModel
from torchebm.losses import ContrastiveDivergence
from torchebm.samplers import LangevinDynamics

model = HarmonicModel(k=1.0)
sampler = LangevinDynamics(model, step_size=0.01)
loss_fn = ContrastiveDivergence(model=model, sampler=sampler, k_steps=5)

# Verify hooks fire
hook_called = []
loss_fn.register_forward_hook(lambda m, i, o: hook_called.append(True))
x = torch.randn(16, 2)
loss, neg = loss_fn(x)
assert len(hook_called) == 1, f"Expected hook to fire once, got {len(hook_called)}"
```

All existing tests pass with this change.

Fixes #135