### PR TITLE
FlowSampler standardization - unified sample() API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All samplers accept an `integrator` constructor argument: `None` (current default), a registry name (`"heun"`, `"rk4"`, `"dopri5"`, ...), or an integrator instance. Compatibility is enforced at construction (Langevin: SDE family; HMC: separable symplectic; RMHMC: non-separable symplectic; Flow: Runge-Kutta family). Passed instances must match the sampler's device/dtype (no implicit `.to()`); integrator hyperparameters (`atol`/`rtol`/solver iterations) are set on the instance, not via sampler kwargs
 - `BaseSymplecticIntegrator` (core): shared base for the leapfrog family with a `separable` contract flag; `LeapfrogIntegrator` and `GeneralisedLeapfrogIntegrator` now inherit from it
 - `get_integrator(name, device, dtype)` string registry in `torchebm.integrators`
+- `torchebm.interpolants.interpolant_utils`: `get_interpolant` moved here from `torchebm.losses.loss_utils` (still re-exported there) plus a new `resolve_interpolant(interpolant, default, owner)` helper mirroring `resolve_integrator`
+- `resolve_integrator` exported from `torchebm.integrators`
+- Cross-sampler API contract test (`tests/samplers/test_api_contract.py`) pinning the shared `sample()` signature, return types, trajectory/thin shapes, and constructor ordering for every sampler
 
 ### Changed
 
+- **BREAKING** `FlowSampler` is configured entirely at construction: `mode="ode"|"sde"` selects the process, and `reverse`, `diffusion_form`, `diffusion_norm`, `last_step`, `last_step_size` are constructor arguments (SDE-only options raise `ValueError` in ODE mode). `sample()` now follows the standard `BaseSampler` contract, including `thin`, `return_trajectory`, and `return_diagnostics` (keys `"mean"`, `"var"`, `"t"`) with fixed-step integrators; adaptive integrators return the final state only. `n_steps=None` resolves to 50 (ODE) / 250 (SDE). Fixed-step sampling now advances schedulers once per step
+- **BREAKING** `sample(x=None)` requires `dim=` (or model-based inference in the HMC family); the silent `dim=10` default is gone. `dim` accepts an int or a shape tuple, replacing `FlowSampler`'s `shape=` kwarg
+- Sampler constructors and `sample()` signatures no longer accept unused `*args, **kwargs`
+- `resolve_integrator` validates the integrator family for registry names too, not only instances (e.g. `FlowSampler(mode="sde", integrator="rk4")` now raises `TypeError` at construction)
+- `RiemannianManifoldHMC` resolves its default integrator through `resolve_integrator` like every other sampler
 - `FlowSampler` adaptive ODE sampling (`dopri5`, `dopri8`, `bosh3`, `adaptive_heun`) now runs on native integrators; torchdiffeq is no longer used or required (removed from the `eqm` extra). Outputs are statistically equivalent but not bitwise identical to torchdiffeq (different step-size controller); the default `dopri5` path is ~3x faster on the sampler benchmark
 - `FlowSampler` reverse-time sampling works with adaptive integrators (decreasing time grids are reparameterized internally)
 
+### Removed
+
+- **BREAKING** `FlowSampler.sample_ode` / `FlowSampler.sample_sde` and the per-call `method`/`atol`/`rtol`/`ode_method`/`sde_method`/`mode`/`shape` sampling kwargs (deprecated in 0.6.4). Passing a removed kwarg raises `TypeError` with a migration hint. Migration:
+
+  | old | new |
+  |---|---|
+  | `s.sample_ode(z, num_steps=50)` | `FlowSampler(model, ...).sample(x=z, n_steps=50)` |
+  | `s.sample_sde(z, num_steps=250, diffusion_form=..., last_step=...)` | `FlowSampler(model, mode="sde", diffusion_form=..., last_step=...).sample(x=z, n_steps=250)` |
+  | `s.sample(mode="sde", ...)` | constructor `mode="sde"` |
+  | `s.sample(shape=(n, C, H, W))` | `s.sample(n_samples=n, dim=(C, H, W))` |
+  | `sample_ode(..., method="rk4", atol=..., rtol=...)` | constructor `integrator="rk4"` or an instance with `atol`/`rtol` set |
+  | `sample_ode(..., reverse=True)` | constructor `reverse=True` |
+
 ### Deprecated
 
-- `FlowSampler` per-call `method`/`atol`/`rtol` (in `sample_ode`/`sample_sde`) and `ode_method`/`sde_method` (in `sample`): pass `integrator=` to the constructor instead
 - `RiemannianManifoldHMC` `solver_max_iter`/`solver_tol`/`solver_check_every`: construct `GeneralisedLeapfrogIntegrator(solver_max_iter=...)` and pass it as `integrator=`
 
 - `EnergyMatchingLoss`: Energy Matching (arXiv:2504.10612) — OT flow-matching warm-up plus contrastive-divergence sharpening on a single time-independent scalar potential, with split Langevin negatives, one-sided trimmed mean, and stability clamp

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -152,7 +152,6 @@ COMPONENT_OVERRIDES: Dict[str, Dict[str, Any]] = {
     },
     "FlowSampler": {
         "model_type": "velocity",
-        "bench_fn": "sample_ode",
         "variants": {
             "flow_sampler_euler": {
                 "init_kwargs": {

--- a/tests/models/test_wrappers.py
+++ b/tests/models/test_wrappers.py
@@ -1,7 +1,10 @@
+import pytest
 import torch
 from torch import nn
 
-from torchebm.models.wrappers import LabelClassifierFreeGuidance
+from torchebm.core import BaseModel, TemperatureScheduler
+from torchebm.models.wrappers import InteractionModel, LabelClassifierFreeGuidance
+from torchebm.samplers import LangevinDynamics
 
 
 class _DummyBase(nn.Module):
@@ -56,3 +59,71 @@ def test_cfg_guide_channels_exceeds_output_clamps():
     out = wrapped(x, t, y=y)
     assert out.shape == (1, 2, 2, 2)
     assert torch.allclose(out, torch.full_like(out, 3.0))
+
+
+# InteractionModel (Energy Matching pairwise repulsion)
+# =====================================================
+
+
+class _Quadratic(BaseModel):
+    def forward(self, x):
+        return 0.5 * x.flatten(1).square().sum(dim=1)
+
+
+def test_interaction_model_energy_two_points():
+    """E_i = V(x_i) - 0.5 * (s / sigma_w^2) * sum_j ||x_i - x_j||^2."""
+    model = InteractionModel(_Quadratic(), sigma_w=1.0, strength=1.0)
+    x = torch.tensor([[0.0, 0.0], [1.0, 1.0]])
+    # V = [0, 1]; ||x_0 - x_1||^2 = 2 -> W = [1, 1]; E = V - W = [-1, 0]
+    energy = model(x)
+    assert torch.allclose(energy, torch.tensor([-1.0, 0.0]), atol=1e-6)
+
+
+def test_interaction_model_zero_strength_matches_base():
+    base = _Quadratic()
+    model = InteractionModel(base, sigma_w=1.0, strength=0.0)
+    x = torch.randn(8, 2)
+    assert torch.allclose(model(x), base(x), atol=1e-6)
+
+
+def test_interaction_model_gradient_analytic():
+    """Batch-coupled drift: grad E_i = x_i - 2 * (s / sigma_w^2) * (x_i - mean-term).
+
+    For B = 2, s = sigma_w = 1: d(sum E)/dx_0 = x_0 - 2 * (x_0 - x_1).
+    """
+    model = InteractionModel(_Quadratic(), sigma_w=1.0, strength=1.0)
+    x = torch.tensor([[0.5, -0.5], [1.5, 2.0]])
+    grad = model.gradient(x)
+    x0, x1 = x[0], x[1]
+    expected = torch.stack([x0 - 2 * (x0 - x1), x1 - 2 * (x1 - x0)])
+    assert torch.allclose(grad, expected, atol=1e-5)
+
+
+def test_interaction_model_scheduler_advances_with_sampler():
+    """The strength scheduler lives in the sampler's subtree and steps with it."""
+    strength = TemperatureScheduler(
+        epsilon_max=0.1, tau_star=0.5, n_steps=10, sqrt=False
+    )
+    model = InteractionModel(_Quadratic(), sigma_w=1.0, strength=strength)
+    sampler = LangevinDynamics(model=model, step_size=0.01, noise_scale=1.0)
+    sampler.sample(x=torch.randn(4, 2), n_steps=7)
+    assert strength.step_count == 7
+
+
+def test_interaction_model_repulsion_increases_spread():
+    """Repulsive sampling spreads a clustered batch further apart."""
+
+    def spread(strength):
+        torch.manual_seed(0)
+        x_init = torch.randn(16, 2) * 0.01
+        model = InteractionModel(_Quadratic(), sigma_w=1.0, strength=strength)
+        sampler = LangevinDynamics(model=model, step_size=0.01, noise_scale=0.01)
+        samples = sampler.sample(x=x_init, n_steps=50)
+        return torch.cdist(samples, samples).mean()
+
+    assert spread(strength=0.4) > spread(strength=0.0) * 2
+
+
+def test_interaction_model_invalid_sigma_w():
+    with pytest.raises(ValueError, match="sigma_w"):
+        InteractionModel(_Quadratic(), sigma_w=0.0)

--- a/tests/samplers/test_api_contract.py
+++ b/tests/samplers/test_api_contract.py
@@ -1,0 +1,257 @@
+r"""Cross-sampler API contract guard.
+
+Every sampler must honor the `BaseSampler` contract: the shared `sample()`
+signature prefix, the ctor ordering (model -> algorithm -> dtype -> device
+-> integrator), tensor-or-(tensor, dict) returns, trajectory/thin shapes,
+and int-or-tuple `dim` synthesis. New samplers get a `Case` entry here.
+"""
+
+import dataclasses
+import inspect
+from typing import Callable
+
+import pytest
+import torch
+import torch.nn as nn
+
+from torchebm.core import GaussianModel
+from torchebm.samplers import (
+    FlowSampler,
+    GradientDescentSampler,
+    HamiltonianMonteCarlo,
+    LangevinDynamics,
+    NesterovSampler,
+    RiemannianManifoldHMC,
+)
+
+_SAMPLE_PREFIX = (
+    "x",
+    "dim",
+    "n_steps",
+    "n_samples",
+    "thin",
+    "return_trajectory",
+    "return_diagnostics",
+    "reset_schedulers",
+)
+
+_SAMPLE_DEFAULTS = {
+    "x": None,
+    "dim": None,
+    "n_samples": 1,
+    "thin": 1,
+    "return_trajectory": False,
+    "return_diagnostics": False,
+    "reset_schedulers": True,
+}
+
+
+class ConstantVelocity(nn.Module):
+    def forward(self, x, t, **kwargs):
+        return torch.ones_like(x)
+
+
+def _gaussian(dim=2):
+    return GaussianModel(mean=torch.zeros(dim), cov=torch.eye(dim))
+
+
+def _identity_metric(x):
+    dim = x.shape[-1]
+    eye = torch.eye(dim, dtype=x.dtype, device=x.device)
+    return eye.expand(x.shape[0], dim, dim).contiguous()
+
+
+@dataclasses.dataclass
+class Case:
+    name: str
+    factory: Callable
+    infers_dim: bool = False
+    supports_trajectory: bool = True
+    tuple_dim: tuple = (2,)
+    has_integrator: bool = True
+    allows_var_keyword: bool = False
+
+
+CASES = [
+    Case(
+        "langevin",
+        lambda: LangevinDynamics(_gaussian(), step_size=0.01),
+    ),
+    Case(
+        "hmc",
+        lambda: HamiltonianMonteCarlo(_gaussian(), step_size=0.05, n_leapfrog_steps=3),
+        infers_dim=True,
+        tuple_dim=None,
+    ),
+    Case(
+        "rmhmc",
+        lambda: RiemannianManifoldHMC(
+            _gaussian(),
+            metric_fn=_identity_metric,
+            step_size=0.05,
+            n_leapfrog_steps=2,
+        ),
+        infers_dim=True,
+        tuple_dim=None,
+    ),
+    Case(
+        "gd",
+        lambda: GradientDescentSampler(_gaussian(), step_size=0.05),
+        has_integrator=False,
+    ),
+    Case(
+        "nesterov",
+        lambda: NesterovSampler(_gaussian(), step_size=0.05),
+        has_integrator=False,
+    ),
+    Case(
+        "flow_ode_fixed",
+        lambda: FlowSampler(ConstantVelocity(), integrator="euler"),
+        tuple_dim=(2, 3),
+        allows_var_keyword=True,
+    ),
+    Case(
+        "flow_sde",
+        lambda: FlowSampler(
+            ConstantVelocity(),
+            mode="sde",
+            diffusion_form="constant",
+            diffusion_norm=0.0,
+            last_step=None,
+            integrator="euler",
+        ),
+        tuple_dim=(2, 3),
+        allows_var_keyword=True,
+    ),
+    Case(
+        "flow_ode_adaptive",
+        lambda: FlowSampler(ConstantVelocity()),
+        supports_trajectory=False,
+        tuple_dim=(2, 3),
+        allows_var_keyword=True,
+    ),
+]
+
+_IDS = [case.name for case in CASES]
+
+
+@pytest.fixture(params=CASES, ids=_IDS)
+def case(request):
+    return request.param
+
+
+class TestSignatures:
+
+    def test_sample_signature_prefix(self, case):
+        sampler_cls = type(case.factory())
+        params = list(inspect.signature(sampler_cls.sample).parameters.values())
+        names = [p.name for p in params]
+        assert names[0] == "self"
+        assert tuple(names[1 : 1 + len(_SAMPLE_PREFIX)]) == _SAMPLE_PREFIX
+
+        kinds = {p.name: p.kind for p in params}
+        assert not any(
+            kind is inspect.Parameter.VAR_POSITIONAL for kind in kinds.values()
+        ), f"{sampler_cls.__name__}.sample must not take *args"
+        var_keyword = [
+            p.name for p in params if p.kind is inspect.Parameter.VAR_KEYWORD
+        ]
+        if case.allows_var_keyword:
+            assert var_keyword == ["model_kwargs"]
+        else:
+            assert (
+                not var_keyword
+            ), f"{sampler_cls.__name__}.sample must not take **kwargs"
+
+        defaults = {p.name: p.default for p in params}
+        for name, expected in _SAMPLE_DEFAULTS.items():
+            assert (
+                defaults[name] == expected
+            ), f"{sampler_cls.__name__}.sample {name} default"
+        # n_steps default is sampler-specific but must exist (int or None).
+        assert defaults["n_steps"] is None or isinstance(defaults["n_steps"], int)
+
+    def test_ctor_signature(self, case):
+        sampler_cls = type(case.factory())
+        params = list(inspect.signature(sampler_cls.__init__).parameters.values())
+        names = [p.name for p in params]
+        assert names[1] == "model"
+        assert not any(
+            p.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+            for p in params
+        ), f"{sampler_cls.__name__}.__init__ must not take *args/**kwargs"
+
+        assert names.index("dtype") < names.index("device")
+        if case.has_integrator:
+            assert names[-1] == "integrator"
+            assert names.index("device") < names.index("integrator")
+        else:
+            assert "integrator" not in names
+
+
+class TestSampleContract:
+
+    def test_returns_tensor(self, case):
+        sampler = case.factory()
+        samples = sampler.sample(n_samples=4, dim=2, n_steps=6)
+        assert isinstance(samples, torch.Tensor)
+        assert samples.shape == (4, 2)
+        assert samples.dtype == sampler.dtype
+        assert samples.device == sampler.device
+
+    def test_diagnostics_contract(self, case):
+        sampler = case.factory()
+        result = sampler.sample(n_samples=4, dim=2, n_steps=6, return_diagnostics=True)
+        assert isinstance(result, tuple) and len(result) == 2
+        samples, diagnostics = result
+        assert isinstance(samples, torch.Tensor)
+        assert isinstance(diagnostics, dict)
+        n_kept = 6 if case.supports_trajectory else 1
+        for key, value in diagnostics.items():
+            assert isinstance(value, torch.Tensor), key
+            assert value.shape[0] == n_kept, key
+
+    @pytest.mark.parametrize("thin", [1, 2, 3])
+    def test_trajectory_and_thin(self, case, thin):
+        sampler = case.factory()
+        if not case.supports_trajectory:
+            with pytest.raises(NotImplementedError):
+                sampler.sample(
+                    n_samples=4,
+                    dim=2,
+                    n_steps=6,
+                    thin=thin,
+                    return_trajectory=True,
+                )
+            return
+        trajectory = sampler.sample(
+            n_samples=4, dim=2, n_steps=6, thin=thin, return_trajectory=True
+        )
+        assert trajectory.shape == (4, 6 // thin, 2)
+
+    def test_thin_below_one_raises(self, case):
+        sampler = case.factory()
+        with pytest.raises(ValueError, match="thin"):
+            sampler.sample(n_samples=2, dim=2, n_steps=4, thin=0)
+
+    def test_x_none_dim_none(self, case):
+        sampler = case.factory()
+        if case.infers_dim:
+            samples = sampler.sample(n_samples=2, n_steps=4)
+            assert samples.shape == (2, 2)
+        else:
+            with pytest.raises(ValueError, match="dim"):
+                sampler.sample(n_samples=2, n_steps=4)
+
+    def test_tuple_dim_synthesis(self, case):
+        if case.tuple_dim is None:
+            pytest.skip("sampler is restricted to flat 2-D states")
+        sampler = case.factory()
+        samples = sampler.sample(n_samples=3, dim=case.tuple_dim, n_steps=4)
+        assert samples.shape == (3, *case.tuple_dim)
+
+    def test_x_passthrough_shape(self, case):
+        sampler = case.factory()
+        x = torch.zeros(5, 2)
+        samples = sampler.sample(x=x, n_steps=4)
+        assert samples.shape == (5, 2)

--- a/tests/samplers/test_flow.py
+++ b/tests/samplers/test_flow.py
@@ -1,12 +1,13 @@
+import math
 
 import pytest
 import torch
 import torch.nn as nn
-import numpy as np
 from torch.testing import assert_close
 
 from torchebm.samplers.flow import FlowSampler, PredictionType
-from torchebm.interpolants import LinearInterpolant, VariancePreservingInterpolant
+from torchebm.interpolants import LinearInterpolant
+
 
 class MockModel(nn.Module):
     def __init__(self, mode="constant", val=0.0):
@@ -16,245 +17,523 @@ class MockModel(nn.Module):
 
     def forward(self, x, t, **kwargs):
         if self.mode == "constant":
-            # Return constant value
             return torch.full_like(x, self.val)
         elif self.mode == "linear":
-            # Return x * val
             return x * self.val
         return torch.zeros_like(x)
 
-class QuadraticEnergy(nn.Module):
-    def gradient(self, x):
-        return x  # E = 0.5 * x^2 -> grad = x
 
 @pytest.fixture
 def device():
     return torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
+
 @pytest.fixture
 def dtype():
     return torch.float32
 
+
 class TestFlowSampler:
-    
+
     def test_initialization(self, device, dtype):
         model = MockModel()
-        sampler = FlowSampler(model, interpolant="linear", prediction="velocity", device=device, dtype=dtype)
+        sampler = FlowSampler(
+            model,
+            interpolant="linear",
+            prediction="velocity",
+            device=device,
+            dtype=dtype,
+        )
         assert sampler.model is model
+        assert sampler.mode == "ode"
         assert isinstance(sampler.interpolant, LinearInterpolant)
         assert sampler.prediction_type == PredictionType.VELOCITY
         assert sampler.device == device
         assert sampler.dtype == dtype
+        assert sampler.last_step is None
+        assert not hasattr(sampler, "sample_ode")
+        assert not hasattr(sampler, "sample_sde")
+
+    def test_sde_defaults(self, device, dtype):
+        sampler = FlowSampler(MockModel(), mode="sde", device=device, dtype=dtype)
+        assert sampler.diffusion_form == "SBDM"
+        assert sampler.diffusion_norm == 1.0
+        assert sampler.last_step == "Mean"
+        assert sampler.last_step_size == 0.04
 
     def test_get_drift_velocity(self, device, dtype):
         # v(x,t) = 2.0
         model = MockModel(mode="constant", val=2.0).to(device)
-        sampler = FlowSampler(model, interpolant="linear", prediction="velocity", device=device, dtype=dtype)
+        sampler = FlowSampler(
+            model,
+            interpolant="linear",
+            prediction="velocity",
+            device=device,
+            dtype=dtype,
+        )
         drift_fn = sampler._get_drift()
-        
+
         x = torch.zeros(1, 1, device=device, dtype=dtype)
         t = torch.zeros(1, device=device, dtype=dtype)
-        
-        # Drift should be just the model output for velocity prediction
+
         out = drift_fn(x, t)
         assert_close(out, torch.full_like(x, 2.0))
 
-    def test_sample_ode_euler_constant_velocity(self, device, dtype):
-        # dx/dt = v(x,t) = 1.0. x(0)=0. x(1) should be 1.0
-        # FlowSampler samples from noise (x(0)) to data (x(1)).
-        # Actually standard flow matching goes from t=0 (source/noise) to t=1 (target/data).
-        # FlowSampler.sample_ode checks interval. 
-        # For LinearInterpolant, t0=0, t1=1-eps.
-        
+    def test_ode_euler_constant_velocity(self, device, dtype):
+        # dx/dt = 1: x(0) = 0 -> x(1) = 1.
         model = MockModel(mode="constant", val=1.0).to(device)
-        sampler = FlowSampler(model, interpolant="linear", prediction="velocity", sample_eps=0.0, device=device, dtype=dtype)
-        
-        # x_0 = 0
+        sampler = FlowSampler(
+            model,
+            interpolant="linear",
+            prediction="velocity",
+            sample_eps=0.0,
+            device=device,
+            dtype=dtype,
+            integrator="euler",
+        )
         z = torch.zeros(1, 1, device=device, dtype=dtype)
-        
-        # Euler with 10 steps
-        # dt = 0.1
-        # x_{k+1} = x_k + 1.0 * 0.1
-        # x_{10} = 0 + 10 * 0.1 = 1.0
-        samples = sampler.sample_ode(z, num_steps=10, method="euler")
+        samples = sampler.sample(x=z, n_steps=10)
         assert_close(samples, torch.full_like(samples, 1.0), atol=1e-5, rtol=1e-5)
 
-    def test_sample_ode_euler_linear_velocity(self, device, dtype):
-        # dx/dt = x. x(0)=1. 
-        # Analytical solution: x(t) = x(0) * e^t.
-        # x(1) = e.
-        
+    def test_ode_euler_linear_velocity(self, device, dtype):
+        # dx/dt = x, x(0) = 1 -> x(1) = e; Euler converges O(dt).
         model = MockModel(mode="linear", val=1.0).to(device)
-        sampler = FlowSampler(model, interpolant="linear", prediction="velocity", sample_eps=0.0, device=device, dtype=dtype)
-        
+        sampler = FlowSampler(
+            model,
+            interpolant="linear",
+            prediction="velocity",
+            sample_eps=0.0,
+            device=device,
+            dtype=dtype,
+            integrator="euler",
+        )
         z = torch.ones(1, 1, device=device, dtype=dtype)
-        
-        # Euler with many steps to approximate analytical solution
-        # x_{k+1} = x_k + x_k * dt = x_k(1+dt)
-        # x_N = x_0 * (1 + 1/N)^N -> e as N -> inf
-        N = 1000
-        samples = sampler.sample_ode(z, num_steps=N, method="euler")
-        
-        expected = torch.ones_like(samples) * np.exp(1.0)
-        # Euler convergence is O(dt), so error is ~ 1/N = 0.001. 
-        # (1+0.001)^1000 approx 2.7169. e approx 2.7182. diff ~ 0.0013.
+        samples = sampler.sample(x=z, n_steps=1000)
+        expected = torch.full_like(samples, math.e)
         assert_close(samples, expected, atol=0.01, rtol=0.01)
 
-    def test_sample_ode_reverse(self, device, dtype):
-        # Reverse sampling: from t=1 to t=0? or just swap t0, t1.
-        # _check_interval: if reverse: t0, t1 = 1-t0, 1-t1. 
-        # So it goes from 1 to 0. 
-        # If dx/dt = 1, then integrating from 1 to 0 gives x(0) = x(1) + \int_1^0 1 dt = x(1) - 1.
-        
+    def test_ode_reverse_fixed_step(self, device, dtype):
+        # dx/dt = 1 integrated from t=1 to t=0: x -> x - 1.
         model = MockModel(mode="constant", val=1.0).to(device)
-        sampler = FlowSampler(model, interpolant="linear", prediction="velocity", sample_eps=0.0, device=device, dtype=dtype)
-        
-        z = torch.zeros(1, 1, device=device, dtype=dtype) # Start at 0
-        
-        # We expect change of -1.0
-        samples = sampler.sample_ode(z, num_steps=10, method="euler", reverse=True)
+        sampler = FlowSampler(
+            model,
+            interpolant="linear",
+            prediction="velocity",
+            sample_eps=0.0,
+            reverse=True,
+            device=device,
+            dtype=dtype,
+            integrator="euler",
+        )
+        z = torch.zeros(1, 1, device=device, dtype=dtype)
+        samples = sampler.sample(x=z, n_steps=10)
         assert_close(samples, torch.full_like(samples, -1.0))
 
-    def test_prediction_score(self, device, dtype):
-        # Test score prediction drift conversion
-        # drift for score: -drift_mean + drift_var * model_output
-        # For LinearInterpolant: x_t = (1-t)x_0 + t x_1
-        # alpha_t = 1-t, beta_t = t (in some formulations) 
-        # Let's check existing interpolant implementation for compute_drift.
-        # Actually LineaInterpolant in torchebm: 
-        # compute_drift returns (drift_mean, drift_var).
-        # Need to know what LinearInterpolant.compute_drift returns.
-        # Assuming simple rectified flow: drift_mean depends on x/t?
-        # Let's trust logic but verify it runs.
-        
+    def test_ode_reverse_adaptive(self, device, dtype):
+        # Same reverse dynamics through the adaptive dopri5 default.
+        model = MockModel(mode="constant", val=1.0).to(device)
+        sampler = FlowSampler(
+            model,
+            interpolant="linear",
+            prediction="velocity",
+            sample_eps=0.0,
+            reverse=True,
+            device=device,
+            dtype=dtype,
+        )
+        z = torch.zeros(4, 2, device=device, dtype=dtype)
+        samples = sampler.sample(x=z, n_steps=10)
+        assert_close(samples, torch.full_like(samples, -1.0), atol=1e-4, rtol=1e-4)
+
+    def test_prediction_score_drift_runs(self, device, dtype):
         interpolant = LinearInterpolant()
-        model = MockModel(mode="constant", val=1.0).to(device) # Score = 1
-        sampler = FlowSampler(model, interpolant=interpolant, prediction="score", device=device, dtype=dtype)
-        
+        model = MockModel(mode="constant", val=1.0).to(device)
+        sampler = FlowSampler(
+            model,
+            interpolant=interpolant,
+            prediction="score",
+            device=device,
+            dtype=dtype,
+        )
         x = torch.randn(2, 2, device=device, dtype=dtype)
-        t = torch.tensor([0.5], device=device, dtype=dtype) # shape (1,)
-        
-        # Should not crash
         drift_fn = sampler._get_drift()
-        # Note: drift_fn expects t as (batch,) or (1,) depending on usage?
-        # In sample_ode: t_batch = ones * t_val.
-        
-        t_batch = torch.ones(x.size(0), device=device, dtype=dtype) * 0.5
+        t_batch = torch.full((x.size(0),), 0.5, device=device, dtype=dtype)
         out = drift_fn(x, t_batch)
         assert out.shape == x.shape
 
-    def test_sample_sde_basic(self, device, dtype):
-        # Just check it runs and produces output of correct shape
+    def test_sde_zero_dynamics_identity(self, device, dtype):
+        # Zero velocity and zero diffusion: samples equal the input.
         model = MockModel(mode="constant", val=0.0).to(device)
-        sampler = FlowSampler(model, interpolant="linear", prediction="velocity", device=device, dtype=dtype)
-        
+        sampler = FlowSampler(
+            model,
+            mode="sde",
+            interpolant="linear",
+            prediction="velocity",
+            diffusion_form="constant",
+            diffusion_norm=0.0,
+            device=device,
+            dtype=dtype,
+            integrator="euler",
+        )
         z = torch.randn(4, 2, device=device, dtype=dtype)
-        samples = sampler.sample_sde(z, num_steps=5, method="euler", diffusion_form="constant", diffusion_norm=0.0)
-        
-        # With 0 diffusion and 0 velocity, samples should equal z
+        samples = sampler.sample(x=z, n_steps=5)
         assert_close(samples, z)
 
     def test_apply_last_step(self, device, dtype):
-        # Test Mean Step: x + drift * step_size
+        # Mean step: x + drift * step_size.
         model = MockModel(mode="constant", val=1.0).to(device)
         sampler = FlowSampler(model, prediction="velocity", device=device, dtype=dtype)
-        
+
         x = torch.zeros(1, 1, device=device, dtype=dtype)
         t = torch.ones(1, device=device, dtype=dtype)
-        
-        # velocity=1. drift=1. step_size=0.1 => x + 1*0.1 = 0.1
+
         out = sampler._apply_last_step(x, t, sampler._get_drift(), "Mean", 0.1)
         assert_close(out, torch.full_like(x, 0.1))
 
     def test_check_interval(self):
-        # Test interval logic
         model = MockModel()
-        # Linear, velocity, no sde -> 0 to 1
-        sampler = FlowSampler(model, interpolant="linear", prediction="velocity", sample_eps=0.01)
-        t0, t1 = sampler._check_interval(sde=False)
-        assert t0 == 0.0
-        assert t1 == 1.0
+        # Linear, velocity, ODE -> (0, 1).
+        sampler = FlowSampler(
+            model, interpolant="linear", prediction="velocity", sample_eps=0.01
+        )
+        assert sampler._check_interval() == (0.0, 1.0)
 
-        
-        # SDE -> t0 gets eps if SBDM
-        t0, t1 = sampler._check_interval(sde=True, diffusion_form="SBDM")
+        # SDE with SBDM and no last-step correction -> (eps, 1 - eps).
+        sampler = FlowSampler(
+            model,
+            mode="sde",
+            interpolant="linear",
+            prediction="velocity",
+            sample_eps=0.01,
+            diffusion_form="SBDM",
+            last_step=None,
+        )
+        t0, t1 = sampler._check_interval()
         assert t0 == 0.01
         assert t1 == 0.99
-        
-        # VP -> t0 always 0? No check logic:
-        # if is_vp: t1 = 1-eps
-        # else: if prediction!=velocity or sde: t0=eps ...
-        
-        sampler_vp = FlowSampler(model, interpolant="vp", prediction="score", sample_eps=0.01)
-        t0, t1 = sampler_vp._check_interval(sde=False)
-        # VP default t0 is 0.0 in _check_interval logic (it is initialized to 0.0 and not changed for VP)
+
+        # SDE with the default Mean last step -> t1 = 1 - last_step_size.
+        sampler = FlowSampler(
+            model,
+            mode="sde",
+            interpolant="linear",
+            prediction="velocity",
+            sample_eps=0.01,
+        )
+        t0, t1 = sampler._check_interval()
+        assert t0 == 0.01
+        assert t1 == pytest.approx(0.96)
+
+        # VP keeps t0 = 0 and clips t1.
+        sampler_vp = FlowSampler(
+            model, interpolant="vp", prediction="score", sample_eps=0.01
+        )
+        t0, t1 = sampler_vp._check_interval()
         assert t0 == 0.0
         assert t1 == 0.99
 
-    @pytest.mark.parametrize("diffusion_form", [
-        "constant", "SBDM", "sigma", "linear", "decreasing", "increasing-decreasing"
-    ])
+    @pytest.mark.parametrize(
+        "diffusion_form",
+        ["constant", "SBDM", "sigma", "linear", "decreasing", "increasing-decreasing"],
+    )
     def test_diffusion_forms(self, device, dtype, diffusion_form):
-        """Test all supported diffusion forms run without errors."""
+        """All supported diffusion forms run without errors."""
         model = MockModel(mode="constant", val=0.0).to(device)
         sampler = FlowSampler(
-            model, 
-            interpolant="linear", 
-            prediction="velocity", 
-            device=device, 
-            dtype=dtype
-        )
-        
-        z = torch.randn(4, 2, device=device, dtype=dtype)
-        # Run with small number of steps, diffusion_norm=0 to keep results stable
-        samples = sampler.sample_sde(
-            z, 
-            num_steps=5, 
-            method="euler", 
+            model,
+            mode="sde",
+            interpolant="linear",
+            prediction="velocity",
             diffusion_form=diffusion_form,
             diffusion_norm=0.0,
+            device=device,
+            dtype=dtype,
+            integrator="euler",
         )
-        
+        z = torch.randn(4, 2, device=device, dtype=dtype)
+        samples = sampler.sample(x=z, n_steps=5)
         assert samples.shape == z.shape
         assert torch.isfinite(samples).all()
 
     def test_invalid_diffusion_form(self, device, dtype):
-        """Test that invalid diffusion form raises error."""
+        """Unknown diffusion form raises at sample time (interpolant check)."""
         model = MockModel(mode="constant", val=0.0).to(device)
-        sampler = FlowSampler(model, interpolant="linear", device=device, dtype=dtype)
-
+        sampler = FlowSampler(
+            model,
+            mode="sde",
+            interpolant="linear",
+            diffusion_form="invalid_form",
+            device=device,
+            dtype=dtype,
+            integrator="euler",
+        )
         z = torch.randn(4, 2, device=device, dtype=dtype)
         with pytest.raises(ValueError, match="Unknown diffusion form"):
-            sampler.sample_sde(z, num_steps=5, diffusion_form="invalid_form")
+            sampler.sample(x=z, n_steps=5)
 
 
-class TestFlowIntegratorArg:
-    """Constructor integrator= arg, deprecations, and torchdiffeq removal."""
+class TestFlowConstructorValidation:
+
+    def test_unknown_mode(self):
+        with pytest.raises(ValueError, match="Unknown mode"):
+            FlowSampler(MockModel(), mode="pde")
+
+    def test_unknown_prediction(self):
+        with pytest.raises(ValueError, match="Unknown prediction"):
+            FlowSampler(MockModel(), prediction="vector")
+
+    def test_unknown_interpolant(self):
+        with pytest.raises(ValueError, match="Unknown interpolant"):
+            FlowSampler(MockModel(), interpolant="spline")
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"diffusion_form": "SBDM"},
+            {"diffusion_norm": 1.0},
+            {"last_step": None},
+            {"last_step": "Mean"},
+            {"last_step_size": 0.04},
+        ],
+    )
+    def test_ode_rejects_sde_only_args(self, kwargs):
+        with pytest.raises(ValueError, match="only apply to mode='sde'"):
+            FlowSampler(MockModel(), mode="ode", **kwargs)
+
+    def test_sde_rejects_reverse(self):
+        with pytest.raises(ValueError, match="reverse"):
+            FlowSampler(MockModel(), mode="sde", reverse=True)
+
+    def test_sde_unknown_last_step(self):
+        with pytest.raises(ValueError, match="Unknown last_step"):
+            FlowSampler(MockModel(), mode="sde", last_step="Midpoint")
+
+    def test_sde_last_step_none_zeroes_size(self):
+        sampler = FlowSampler(MockModel(), mode="sde", last_step=None)
+        assert sampler.last_step_size == 0.0
+
+    def test_ctor_rejects_wrong_family_instance(self, device, dtype):
+        from torchebm.integrators import LeapfrogIntegrator
+
+        with pytest.raises(TypeError, match="BaseRungeKuttaIntegrator"):
+            FlowSampler(
+                MockModel(),
+                device=device,
+                dtype=dtype,
+                integrator=LeapfrogIntegrator(device=device, dtype=dtype),
+            )
+
+    def test_sde_rejects_ode_only_integrator(self, device, dtype):
+        from torchebm.integrators import Dopri5Integrator
+
+        with pytest.raises(TypeError, match="BaseSDERungeKuttaIntegrator"):
+            FlowSampler(
+                MockModel(),
+                mode="sde",
+                device=device,
+                dtype=dtype,
+                integrator=Dopri5Integrator(device=device, dtype=dtype),
+            )
+
+    def test_sde_rejects_ode_only_integrator_name(self, device, dtype):
+        with pytest.raises(TypeError, match="BaseSDERungeKuttaIntegrator"):
+            FlowSampler(
+                MockModel(),
+                mode="sde",
+                device=device,
+                dtype=dtype,
+                integrator="rk4",
+            )
+
+
+class TestFlowSampleContract:
+    """FlowSampler honors the full BaseSampler.sample contract."""
+
+    def _euler_sampler(self, device, dtype, **kwargs):
+        model = MockModel(mode="constant", val=1.0).to(device)
+        return FlowSampler(
+            model,
+            interpolant="linear",
+            prediction="velocity",
+            sample_eps=0.0,
+            device=device,
+            dtype=dtype,
+            integrator=kwargs.pop("integrator", "euler"),
+            **kwargs,
+        )
+
+    def test_trajectory_and_thin(self, device, dtype):
+        # dx/dt = 1 from x = 0: state at step k is k/6.
+        sampler = self._euler_sampler(device, dtype)
+        z = torch.zeros(4, 2, device=device, dtype=dtype)
+        trajectory = sampler.sample(x=z, n_steps=6, thin=2, return_trajectory=True)
+        assert trajectory.shape == (4, 3, 2)
+        expected_t = torch.tensor([2 / 6, 4 / 6, 1.0], device=device, dtype=dtype)
+        assert_close(
+            trajectory,
+            expected_t.view(1, 3, 1).expand(4, 3, 2),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+
+    def test_diagnostics_keys_and_values(self, device, dtype):
+        sampler = self._euler_sampler(device, dtype)
+        z = torch.zeros(4, 2, device=device, dtype=dtype)
+        samples, diagnostics = sampler.sample(
+            x=z, n_steps=6, thin=2, return_diagnostics=True
+        )
+        assert samples.shape == (4, 2)
+        assert set(diagnostics) == {"mean", "var", "t"}
+        assert diagnostics["mean"].shape == (3, 2)
+        assert diagnostics["var"].shape == (3, 2)
+        assert diagnostics["t"].shape == (3,)
+        assert_close(
+            diagnostics["t"],
+            torch.tensor([2 / 6, 4 / 6, 1.0], device=device, dtype=dtype),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+        # Deterministic dynamics: batch mean equals the trajectory value.
+        assert_close(
+            diagnostics["mean"][-1],
+            torch.ones(2, device=device, dtype=dtype),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+
+    def test_adaptive_rejects_trajectory_and_thin(self, device, dtype):
+        sampler = self._euler_sampler(device, dtype, integrator="dopri5")
+        z = torch.zeros(2, 2, device=device, dtype=dtype)
+        with pytest.raises(NotImplementedError, match="fixed-step"):
+            sampler.sample(x=z, n_steps=10, return_trajectory=True)
+        with pytest.raises(NotImplementedError, match="fixed-step"):
+            sampler.sample(x=z, n_steps=10, thin=2)
+
+    def test_adaptive_diagnostics_single_entry(self, device, dtype):
+        sampler = self._euler_sampler(device, dtype, integrator="dopri5")
+        z = torch.zeros(4, 2, device=device, dtype=dtype)
+        samples, diagnostics = sampler.sample(x=z, n_steps=10, return_diagnostics=True)
+        assert diagnostics["mean"].shape == (1, 2)
+        assert diagnostics["var"].shape == (1, 2)
+        assert diagnostics["t"].shape == (1,)
+        assert_close(diagnostics["mean"][0], samples.mean(dim=0), atol=1e-6, rtol=1e-6)
+
+    def test_default_n_steps_per_mode(self, device, dtype):
+        ode = self._euler_sampler(device, dtype)
+        z = torch.zeros(2, 2, device=device, dtype=dtype)
+        _, diagnostics = ode.sample(x=z, return_diagnostics=True)
+        assert diagnostics["t"].shape == (50,)
+
+        model = MockModel(mode="constant", val=0.0).to(device)
+        sde = FlowSampler(
+            model,
+            mode="sde",
+            interpolant="linear",
+            diffusion_form="constant",
+            diffusion_norm=0.0,
+            last_step=None,
+            device=device,
+            dtype=dtype,
+            integrator="euler",
+        )
+        _, diagnostics = sde.sample(x=z, return_diagnostics=True)
+        assert diagnostics["t"].shape == (250,)
+
+    def test_sde_last_step_updates_trajectory_end(self, device, dtype):
+        # dx/dt = 1 with zero diffusion: interval end 0.96, Mean step adds
+        # the remaining 0.04, so the returned sample and the recorded end
+        # state both reach 1.0.
+        model = MockModel(mode="constant", val=1.0).to(device)
+        sampler = FlowSampler(
+            model,
+            mode="sde",
+            interpolant="linear",
+            prediction="velocity",
+            sample_eps=0.0,
+            diffusion_form="constant",
+            diffusion_norm=0.0,
+            device=device,
+            dtype=dtype,
+            integrator="euler",
+        )
+        z = torch.zeros(4, 2, device=device, dtype=dtype)
+        trajectory, diagnostics = sampler.sample(
+            x=z, n_steps=6, return_trajectory=True, return_diagnostics=True
+        )
+        assert_close(
+            trajectory[:, -1],
+            torch.ones(4, 2, device=device, dtype=dtype),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+        assert_close(
+            diagnostics["t"][-1],
+            torch.tensor(1.0, device=device, dtype=dtype),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+
+    def test_dim_tuple_synthesis(self, device, dtype):
+        sampler = self._euler_sampler(device, dtype)
+        samples = sampler.sample(n_samples=3, dim=(2, 4), n_steps=2)
+        assert samples.shape == (3, 2, 4)
+
+    def test_x_none_dim_none_raises(self, device, dtype):
+        sampler = self._euler_sampler(device, dtype)
+        with pytest.raises(ValueError, match="dim must be provided"):
+            sampler.sample(n_samples=3, n_steps=2)
+
+    def test_invalid_thin_and_n_steps(self, device, dtype):
+        sampler = self._euler_sampler(device, dtype)
+        z = torch.zeros(2, 2, device=device, dtype=dtype)
+        with pytest.raises(ValueError, match="thin"):
+            sampler.sample(x=z, n_steps=4, thin=0)
+        with pytest.raises(ValueError, match="n_steps"):
+            sampler.sample(x=z, n_steps=0)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"mode": "sde"},
+            {"shape": (4, 2)},
+            {"ode_method": "euler"},
+            {"method": "euler"},
+            {"atol": 1e-5},
+            {"reverse": True},
+            {"diffusion_form": "SBDM"},
+            {"last_step": "Mean"},
+            {"num_steps": 10},
+            {"z": None},
+        ],
+    )
+    def test_removed_kwargs_raise(self, device, dtype, kwargs):
+        sampler = self._euler_sampler(device, dtype)
+        with pytest.raises(TypeError, match="removed from"):
+            sampler.sample(n_samples=2, dim=2, n_steps=4, **kwargs)
+
+
+class TestFlowIntegrators:
+    """Constructor integrator= injection across the registry."""
 
     def _sampler(self, device, dtype, **kwargs):
         model = MockModel(mode="linear", val=1.0).to(device)
         return FlowSampler(
-            model, interpolant="linear", prediction="velocity",
-            sample_eps=0.0, device=device, dtype=dtype, **kwargs,
+            model,
+            interpolant="linear",
+            prediction="velocity",
+            sample_eps=0.0,
+            device=device,
+            dtype=dtype,
+            **kwargs,
         )
 
-    def test_ctor_integrator_matches_deprecated_method(self, device, dtype):
-        """Fixed-step euler path is bitwise identical either way."""
-        z = torch.randn(8, 2, device=device, dtype=dtype)
-        new_api = self._sampler(device, dtype, integrator="euler")
-        out_new = new_api.sample_ode(z.clone(), num_steps=20)
-        old_api = self._sampler(device, dtype)
-        with pytest.warns(DeprecationWarning, match="method/atol/rtol"):
-            out_old = old_api.sample_ode(z.clone(), num_steps=20, method="euler")
-        assert torch.equal(out_new, out_old)
-
     def test_default_integrator_is_adaptive_dopri5(self, device, dtype):
-        """Default sample_ode runs natively (dopri5) and matches euler closely."""
-        # dx/dt = x, x(0) = 1 -> x(1) = e
+        # dx/dt = x, x(0) = 1 -> x(1) = e.
         sampler = self._sampler(device, dtype)
+        assert sampler.integrator.error_weights is not None
         z = torch.ones(1, 1, device=device, dtype=dtype)
-        samples = sampler.sample_ode(z, num_steps=50)
-        expected = torch.full_like(samples, np.exp(1.0))
+        samples = sampler.sample(x=z, n_steps=50)
+        expected = torch.full_like(samples, math.e)
         assert_close(samples, expected, atol=1e-3, rtol=1e-3)
 
     @pytest.mark.parametrize(
@@ -263,62 +542,18 @@ class TestFlowIntegratorArg:
     def test_registry_strings_run(self, device, dtype, name):
         sampler = self._sampler(device, dtype, integrator=name)
         z = torch.ones(4, 2, device=device, dtype=dtype)
-        samples = sampler.sample_ode(z, num_steps=20)
-        expected = torch.full_like(samples, np.exp(1.0))
+        samples = sampler.sample(x=z, n_steps=20)
+        expected = torch.full_like(samples, math.e)
         assert_close(samples, expected, atol=0.15, rtol=0.05)
 
-    def test_reverse_with_adaptive_integrator(self, device, dtype):
-        """Adaptive reverse integration (decreasing grid reparameterized)."""
-        # dx/dt = 1: reverse integrates from t=1 to t=0, so x -> x - 1.
-        model = MockModel(mode="constant", val=1.0).to(device)
-        sampler = FlowSampler(
-            model, interpolant="linear", prediction="velocity",
-            sample_eps=0.0, device=device, dtype=dtype,
-        )
-        z = torch.zeros(4, 2, device=device, dtype=dtype)
-        samples = sampler.sample_ode(z, num_steps=10, reverse=True)
-        assert_close(samples, torch.full_like(samples, -1.0), atol=1e-4, rtol=1e-4)
-
-    def test_sample_forwards_deprecated_kwargs(self, device, dtype):
-        sampler = self._sampler(device, dtype)
-        with pytest.warns(DeprecationWarning, match="method/atol/rtol"):
-            samples = sampler.sample(
-                n_samples=4, dim=2, n_steps=10,
-                ode_method="euler", atol=1e-5, rtol=1e-3,
-            )
-        assert samples.shape == (4, 2)
-        assert torch.isfinite(samples).all()
-
-    def test_sde_requires_sde_integrator(self, device, dtype):
-        from torchebm.integrators import Dopri5Integrator
-
-        sampler = self._sampler(
-            device, dtype,
-            integrator=Dopri5Integrator(device=device, dtype=dtype),
-        )
-        z = torch.randn(4, 2, device=device, dtype=dtype)
-        with pytest.raises(TypeError, match="BaseSDERungeKuttaIntegrator"):
-            sampler.sample_sde(z, num_steps=5, diffusion_norm=0.0)
-
-    def test_sde_integrator_works_in_both_modes(self, device, dtype):
+    def test_sde_integrator_valid_in_ode_mode(self, device, dtype):
         from torchebm.integrators import EulerMaruyamaIntegrator
 
         sampler = self._sampler(
-            device, dtype,
+            device,
+            dtype,
             integrator=EulerMaruyamaIntegrator(device=device, dtype=dtype),
         )
         z = torch.randn(4, 2, device=device, dtype=dtype)
-        ode_out = sampler.sample_ode(z, num_steps=10)
-        sde_out = sampler.sample_sde(z, num_steps=10, diffusion_norm=0.0)
-        assert torch.isfinite(ode_out).all()
-        assert torch.isfinite(sde_out).all()
-
-    def test_ctor_rejects_wrong_family(self, device, dtype):
-        from torchebm.integrators import LeapfrogIntegrator
-
-        with pytest.raises(TypeError, match="BaseRungeKuttaIntegrator"):
-            self._sampler(
-                device, dtype,
-                integrator=LeapfrogIntegrator(device=device, dtype=dtype),
-            )
-
+        samples = sampler.sample(x=z, n_steps=10)
+        assert torch.isfinite(samples).all()

--- a/torchebm/core/base_sampler.py
+++ b/torchebm/core/base_sampler.py
@@ -39,32 +39,57 @@ class BaseSampler(Schedulable, TorchEBMModule, ABC):
         model: nn.Module,
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
-        *args,
-        **kwargs,
     ):
-        super().__init__(device=device, dtype=dtype, *args, **kwargs)
+        super().__init__(device=device, dtype=dtype)
         self.model = model
+
+    def _init_state(
+        self,
+        x: Optional[torch.Tensor],
+        dim: Optional[Union[int, Tuple[int, ...]]],
+        n_samples: int,
+    ) -> torch.Tensor:
+        r"""Coerce `x` to the sampler's device/dtype, or draw from `N(0, I)`.
+
+        Args:
+            x: Initial state, or `None` to synthesize one.
+            dim: State dimension (int) or shape (tuple), used when `x is None`.
+            n_samples: Number of parallel chains, used when `x is None`.
+
+        Returns:
+            State tensor of shape `[n_samples, *shape]`.
+
+        Raises:
+            ValueError: If both `x` and `dim` are `None`.
+        """
+        if x is not None:
+            return x.to(device=self.device, dtype=self.dtype)
+        if dim is None:
+            raise ValueError("dim must be provided when x is None")
+        shape = (dim,) if isinstance(dim, int) else tuple(dim)
+        return torch.randn(n_samples, *shape, dtype=self.dtype, device=self.device)
 
     @abstractmethod
     def sample(
         self,
         x: Optional[torch.Tensor] = None,
-        dim: int = 10,
+        dim: Optional[Union[int, Tuple[int, ...]]] = None,
         n_steps: int = 100,
         n_samples: int = 1,
         thin: int = 1,
         return_trajectory: bool = False,
         return_diagnostics: bool = False,
         reset_schedulers: bool = True,
-        *args,
-        **kwargs,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
         r"""
         Run the sampling process.
 
         Args:
             x: Initial state. If `None`, samples from `N(0, I)`.
-            dim: Dimension of the state space (used when `x is None`).
+            dim: Dimension (int) or shape (tuple) of the state space, used when
+                `x is None`. Samplers that can infer it from the model (the HMC
+                family, via `model.mean`) accept `None`; otherwise a
+                `ValueError` is raised.
             n_steps: Number of MCMC steps.
             n_samples: Number of parallel chains/samples.
             thin: Keep every `thin`-th sample. Final stored length is
@@ -84,6 +109,7 @@ class BaseSampler(Schedulable, TorchEBMModule, ABC):
             optionally paired with a diagnostics dict if `return_diagnostics=True`.
 
         Raises:
-            ValueError: If `thin < 1`.
+            ValueError: If `thin < 1`, or if `x` is `None` and `dim` is `None`
+                for samplers that cannot infer the state shape.
         """
         raise NotImplementedError

--- a/torchebm/integrators/__init__.py
+++ b/torchebm/integrators/__init__.py
@@ -7,6 +7,7 @@ package import time.  Direct imports still work:
 
 __all__ = [
     "get_integrator",
+    "resolve_integrator",
     "EulerMaruyamaIntegrator",
     "BackwardEulerMaruyamaIntegrator",
     "HeunIntegrator",

--- a/torchebm/integrators/integrator_utils.py
+++ b/torchebm/integrators/integrator_utils.py
@@ -45,9 +45,7 @@ def get_integrator(
         cls_name = _INTEGRATOR_NAMES[name]
     except (KeyError, TypeError):
         valid = ", ".join(sorted(_INTEGRATOR_NAMES))
-        raise ValueError(
-            f"Unknown integrator {name!r}. Valid names: {valid}"
-        ) from None
+        raise ValueError(f"Unknown integrator {name!r}. Valid names: {valid}") from None
     # Resolve through the package's lazy __getattr__ to avoid import cycles.
     cls = getattr(importlib.import_module("torchebm.integrators"), cls_name)
     return cls(device=device, dtype=dtype)
@@ -82,26 +80,34 @@ def resolve_integrator(
         A validated integrator instance.
 
     Raises:
-        TypeError: If an instance is not of the required ``family``.
+        TypeError: If the resolved integrator is not of the required
+            ``family`` (validated for names and instances alike).
         ValueError: If an instance's device/dtype mismatches the sampler's.
     """
-    if integrator is None:
-        return get_integrator(default, device=device, dtype=dtype)
-    if isinstance(integrator, str):
-        return get_integrator(integrator, device=device, dtype=dtype)
-    if not isinstance(integrator, family):
+    if isinstance(integrator, BaseIntegrator):
+        if not isinstance(integrator, family):
+            raise TypeError(
+                f"{owner} requires a {family.__name__}; got "
+                f"{type(integrator).__name__}"
+            )
+        if integrator.device != device or integrator.dtype != dtype:
+            raise ValueError(
+                f"{owner} device/dtype ({device}, {dtype}) does not match the "
+                f"integrator's ({integrator.device}, {integrator.dtype}). "
+                f"Construct the integrator with matching device/dtype; no "
+                f"implicit .to() is performed."
+            )
+        return integrator
+    resolved = get_integrator(
+        integrator if integrator is not None else default,
+        device=device,
+        dtype=dtype,
+    )
+    if not isinstance(resolved, family):
         raise TypeError(
-            f"{owner} requires a {family.__name__}; got "
-            f"{type(integrator).__name__}"
+            f"{owner} requires a {family.__name__}; got " f"{type(resolved).__name__}"
         )
-    if integrator.device != device or integrator.dtype != dtype:
-        raise ValueError(
-            f"{owner} device/dtype ({device}, {dtype}) does not match the "
-            f"integrator's ({integrator.device}, {integrator.dtype}). "
-            f"Construct the integrator with matching device/dtype; no "
-            f"implicit .to() is performed."
-        )
-    return integrator
+    return resolved
 
 
 def _integrate_time_grid(

--- a/torchebm/interpolants/__init__.py
+++ b/torchebm/interpolants/__init__.py
@@ -9,12 +9,16 @@ __all__ = [
     "LinearInterpolant",
     "CosineInterpolant",
     "VariancePreservingInterpolant",
+    "get_interpolant",
+    "resolve_interpolant",
 ]
 
 _LAZY_IMPORTS = {
     "LinearInterpolant": ".linear",
     "CosineInterpolant": ".cosine",
     "VariancePreservingInterpolant": ".variance_preserving",
+    "get_interpolant": ".interpolant_utils",
+    "resolve_interpolant": ".interpolant_utils",
 }
 
 

--- a/torchebm/interpolants/interpolant_utils.py
+++ b/torchebm/interpolants/interpolant_utils.py
@@ -1,0 +1,69 @@
+import importlib
+from typing import Union
+
+from torchebm.core import BaseInterpolant
+
+_INTERPOLANT_NAMES = {
+    "linear": "LinearInterpolant",
+    "cosine": "CosineInterpolant",
+    "vp": "VariancePreservingInterpolant",
+}
+
+
+def get_interpolant(interpolant_type: str) -> BaseInterpolant:
+    r"""Get interpolant instance by name.
+
+    Args:
+        interpolant_type: One of 'linear', 'cosine', or 'vp'.
+
+    Returns:
+        Interpolant instance.
+
+    Raises:
+        ValueError: If interpolant_type is not recognized.
+    """
+    try:
+        cls_name = _INTERPOLANT_NAMES[interpolant_type]
+    except (KeyError, TypeError):
+        valid = list(_INTERPOLANT_NAMES)
+        raise ValueError(
+            f"Unknown interpolant: {interpolant_type}. Choose from {valid}"
+        ) from None
+    # Resolve through the package's lazy __getattr__ to avoid import cycles.
+    cls = getattr(importlib.import_module("torchebm.interpolants"), cls_name)
+    return cls()
+
+
+def resolve_interpolant(
+    interpolant: Union[str, BaseInterpolant, None],
+    *,
+    default: str,
+    owner: str,
+) -> BaseInterpolant:
+    r"""Resolve an ``interpolant`` argument to a validated instance.
+
+    ``None`` and string inputs construct via `get_interpolant`. Instances
+    are validated against `BaseInterpolant` and used as-is. Interpolants
+    are stateless math objects, so no device/dtype handling is needed.
+
+    Args:
+        interpolant: ``None`` (use ``default``), a registry name, or an
+            interpolant instance.
+        default: Registry name used when ``interpolant`` is ``None``.
+        owner: Owning class name, used in error messages.
+
+    Returns:
+        A validated interpolant instance.
+
+    Raises:
+        TypeError: If an instance is not a `BaseInterpolant`.
+    """
+    if interpolant is None:
+        return get_interpolant(default)
+    if isinstance(interpolant, str):
+        return get_interpolant(interpolant)
+    if not isinstance(interpolant, BaseInterpolant):
+        raise TypeError(
+            f"{owner} requires a BaseInterpolant; got " f"{type(interpolant).__name__}"
+        )
+    return interpolant

--- a/torchebm/losses/energy_matching.py
+++ b/torchebm/losses/energy_matching.py
@@ -61,9 +61,9 @@ from torchebm.core import (
     TemperatureScheduler,
 )
 from torchebm.couplings import resolve_coupling
+from torchebm.interpolants import resolve_interpolant
 from torchebm.losses.loss_utils import (
     compute_flow_weight,
-    get_interpolant,
     mean_flat,
     trimmed_mean,
 )
@@ -188,8 +188,8 @@ class EnergyMatchingLoss(BaseLoss):
         self.coupling = resolve_coupling(
             coupling, default="ot", owner="EnergyMatchingLoss"
         )
-        self.interpolant = (
-            get_interpolant(interpolant) if isinstance(interpolant, str) else interpolant
+        self.interpolant = resolve_interpolant(
+            interpolant, default="linear", owner="EnergyMatchingLoss"
         )
         self._register_param("sigma", sigma)
         self._register_param("lambda_cd", lambda_cd)

--- a/torchebm/losses/equilibrium_matching.py
+++ b/torchebm/losses/equilibrium_matching.py
@@ -33,9 +33,9 @@ import torch
 from torch import nn
 
 from torchebm.core import BaseLoss, BaseInterpolant, BaseScheduler, expand_t_like_x
+from torchebm.interpolants import resolve_interpolant
 from torchebm.losses import (
     mean_flat,
-    get_interpolant,
     compute_eqm_ct,
     dispersive_loss,
 )
@@ -135,10 +135,9 @@ class EquilibriumMatchingLoss(BaseLoss):
         self.apply_dispersion = apply_dispersion
         self.dispersion_weight = dispersion_weight
         self.time_invariant = time_invariant
-        if isinstance(interpolant, str):
-            self.interpolant = get_interpolant(interpolant)
-        else:
-            self.interpolant = interpolant
+        self.interpolant = resolve_interpolant(
+            interpolant, default="linear", owner="EquilibriumMatchingLoss"
+        )
 
     @property
     def train_eps(self) -> float:

--- a/torchebm/losses/loss_utils.py
+++ b/torchebm/losses/loss_utils.py
@@ -2,12 +2,7 @@ r"""Utility functions for loss computations."""
 
 import torch
 
-from torchebm.core import BaseInterpolant
-from torchebm.interpolants import (
-    LinearInterpolant,
-    CosineInterpolant,
-    VariancePreservingInterpolant,
-)
+from torchebm.interpolants.interpolant_utils import get_interpolant
 
 
 def mean_flat(tensor: torch.Tensor) -> torch.Tensor:
@@ -20,31 +15,6 @@ def mean_flat(tensor: torch.Tensor) -> torch.Tensor:
         Tensor of shape (batch_size,) with mean over spatial dims.
     """
     return tensor.mean(dim=list(range(1, len(tensor.shape))))
-
-
-def get_interpolant(interpolant_type: str) -> BaseInterpolant:
-    r"""Get interpolant instance by name.
-
-    Args:
-        interpolant_type: One of 'linear', 'cosine', or 'vp'.
-
-    Returns:
-        Interpolant instance.
-
-    Raises:
-        ValueError: If interpolant_type is not recognized.
-    """
-    interpolants = {
-        "linear": LinearInterpolant,
-        "cosine": CosineInterpolant,
-        "vp": VariancePreservingInterpolant,
-    }
-    if interpolant_type not in interpolants:
-        raise ValueError(
-            f"Unknown interpolant: {interpolant_type}. "
-            f"Choose from {list(interpolants.keys())}"
-        )
-    return interpolants[interpolant_type]()
 
 
 def trimmed_mean(values: torch.Tensor, trim_fraction: float) -> torch.Tensor:

--- a/torchebm/models/__init__.py
+++ b/torchebm/models/__init__.py
@@ -12,6 +12,7 @@ This package therefore exposes *reusable building blocks* under
 __all__ = [
     "ConditionalTransformer2D",
     "LabelClassifierFreeGuidance",
+    "InteractionModel",
     "MLPTimestepEmbedder",
     "LabelEmbedder",
     "build_2d_sincos_pos_embed",
@@ -27,6 +28,7 @@ __all__ = [
 _LAZY_IMPORTS = {
     "ConditionalTransformer2D": ".conditional_transformer_2d",
     "LabelClassifierFreeGuidance": ".wrappers",
+    "InteractionModel": ".wrappers",
     "AdaLNZeroBlock": ".components",
     "AdaLNZeroPatchHead": ".components",
     "ConvPatchEmbed2d": ".components",

--- a/torchebm/models/wrappers.py
+++ b/torchebm/models/wrappers.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
+
+from torchebm.core import BaseModel, BaseScheduler, Schedulable
 
 
 class LabelClassifierFreeGuidance(nn.Module):
@@ -51,3 +53,104 @@ class LabelClassifierFreeGuidance(nn.Module):
         if c == cond.shape[1]:
             return guided
         return torch.cat([guided, uncond[:, c:]], dim=1)
+
+
+class InteractionModel(Schedulable, BaseModel):
+    r"""Potential with pairwise repulsive interaction for diverse sampling.
+
+    Wraps a scalar potential \(V(x)\) with the Energy Matching interaction
+    energy (Balcerak et al., 2025, arXiv:2504.10612):
+
+    \[
+    E_i = V(x_i) - W_i, \qquad
+    W_i = \frac{1}{2} \frac{s}{\sigma_W^2} \sum_{j} \|x_i - x_j\|^2
+    \]
+
+    so that \(\sum_i W_i = \tfrac{1}{2} \tfrac{s}{\sigma_W^2}
+    \sum_{i \neq j} \|x_i - x_j\|^2\). Because `BaseModel.gradient()`
+    differentiates the summed batch energy, sampling with this model yields
+    the batch-coupled repulsive Langevin drift of the paper: samples are
+    pushed apart, increasing diversity (used for inverse design and
+    conditional generation).
+
+    The strength \(s\) is a `Schedulable` parameter. Pass a
+    `TemperatureScheduler(..., sqrt=False)` to reproduce the paper's
+    \(\epsilon(t)\)-scaled interaction: the wrapper sits inside the sampler's
+    module subtree, so `LangevinDynamics.sample()` resets and advances it in
+    lockstep with the noise schedule.
+
+    Note:
+        The squared distances use the expansion
+        \(\sum_j \|x_i - x_j\|^2 = B \|x_i\|^2 + \sum_j \|x_j\|^2
+        - 2 x_i \cdot \sum_j x_j\), which is exact, O(batch x dim), and
+        differentiable everywhere (`torch.cdist` has a NaN derivative on the
+        zero diagonal).
+
+    Note:
+        The repulsive drift on each sample scales as
+        \(2 s B / \sigma_W^2 \cdot (x_i - \bar{x})\) for batch size \(B\).
+        Keep \(2 s B \Delta t / \sigma_W^2 \ll 1\) or the chains expand
+        exponentially; for \(s = 0.15\), \(B = 64\), \(\Delta t = 0.01\)
+        this means \(\sigma_W \gtrsim 4\).
+
+    Args:
+        model: Base potential \(V(x)\) returning shape (batch_size,).
+        sigma_w: Interaction bandwidth \(\sigma_W\). Must be positive.
+        strength: Interaction strength \(s\), typically the temperature
+            \(\epsilon(t)\). Float or `BaseScheduler`.
+
+    Example:
+        ```python
+        from torchebm.core import TemperatureScheduler
+        from torchebm.models import InteractionModel
+        from torchebm.samplers import LangevinDynamics
+
+        temp_noise = TemperatureScheduler(0.15, 0.8, n_steps=325, t_end=3.25)
+        temp_strength = TemperatureScheduler(
+            0.15, 0.8, n_steps=325, t_end=3.25, sqrt=False
+        )
+        repulsive = InteractionModel(V, sigma_w=4.0, strength=temp_strength)
+        sampler = LangevinDynamics(
+            model=repulsive, step_size=0.01, noise_scale=temp_noise
+        )
+        samples = sampler.sample(x=torch.randn(64, 2), n_steps=325)
+        ```
+    """
+
+    def __init__(
+        self,
+        model: BaseModel,
+        sigma_w: float,
+        strength: Union[float, BaseScheduler] = 1.0,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        if sigma_w <= 0:
+            raise ValueError(f"sigma_w must be positive, got {sigma_w}")
+        self.model = model
+        self.sigma_w = float(sigma_w)
+        self._register_param("strength", strength)
+
+    @property
+    def strength(self) -> float:
+        return self.get_scheduled_value("strength")
+
+    @strength.setter
+    def strength(self, value: Union[float, BaseScheduler]) -> None:
+        self._register_param("strength", value)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        r"""Compute the interacting energy \(V(x_i) - W_i\) per sample."""
+        batch = x.shape[0]
+        flat = x.reshape(batch, -1)
+        sq_norms = flat.square().sum(dim=1)
+        pair_sq = batch * sq_norms + sq_norms.sum() - 2.0 * flat @ flat.sum(dim=0)
+        w = 0.5 * (self.strength / self.sigma_w**2) * pair_sq
+        return self.model(x) - w
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"model={type(self.model).__name__}, sigma_w={self.sigma_w})"
+        )

--- a/torchebm/samplers/flow.py
+++ b/torchebm/samplers/flow.py
@@ -1,16 +1,15 @@
 r"""Flow-based sampler for trained generative models.
 
-Supports both ODE (probability flow) and SDE (diffusion) sampling modes
-with various numerical integration methods.
+Supports ODE (probability flow) and SDE (diffusion) sampling, configured at
+construction and executed through the standard `BaseSampler.sample` contract.
 """
 
 import enum
-import warnings
-from typing import Callable, Literal, Optional, Tuple, Union
+import math
+from typing import Callable, Dict, Literal, Optional, Tuple, Union
 
 import torch
 from torch import nn
-import numpy as np
 
 from torchebm.core import (
     BaseInterpolant,
@@ -20,18 +19,40 @@ from torchebm.core import (
     BaseSDERungeKuttaIntegrator,
     expand_t_like_x,
 )
-from torchebm.integrators.integrator_utils import (
-    get_integrator,
-    resolve_integrator,
-)
+from torchebm.integrators.integrator_utils import resolve_integrator
 from torchebm.interpolants import (
-    # BaseInterpolant,
-    LinearInterpolant,
     CosineInterpolant,
+    LinearInterpolant,
     VariancePreservingInterpolant,
-    # expand_t_like_x,
 )
-from torchebm.losses.loss_utils import get_interpolant
+from torchebm.interpolants.interpolant_utils import resolve_interpolant
+
+# Sampling-call kwargs removed with the sample_ode/sample_sde retirement.
+# Guarded so stale call sites fail loudly instead of silently forwarding
+# these to the model.
+_REMOVED_SAMPLE_KWARGS = frozenset(
+    {
+        "mode",
+        "shape",
+        "ode_method",
+        "sde_method",
+        "method",
+        "atol",
+        "rtol",
+        "reverse",
+        "diffusion_form",
+        "diffusion_norm",
+        "last_step",
+        "last_step_size",
+        "num_steps",
+        "z",
+    }
+)
+
+# Sentinel distinguishing "not passed" from the legitimate last_step=None.
+_UNSET = object()
+
+_LAST_STEPS = ("Mean", "Euler", "Tweedie", None)
 
 
 class PredictionType(enum.Enum):
@@ -46,12 +67,18 @@ class FlowSampler(BaseSampler):
     r"""
     Sampler for flow-based and diffusion generative models.
 
-    Supports ODE (probability flow) and SDE (diffusion) sampling with various
-    numerical integration methods including Euler, Heun, and adaptive solvers.
+    The sampling process is configured at construction: ``mode="ode"``
+    integrates the probability-flow ODE, ``mode="sde"`` the reverse-time
+    diffusion SDE. `sample()` follows the standard `BaseSampler` contract;
+    with a fixed-step integrator it supports ``thin``, ``return_trajectory``,
+    and ``return_diagnostics``, while adaptive integrators (``dopri5``, ...)
+    return only the final state.
 
     Args:
-        model: Trained neural network predicting velocity/score/noise.
-        interpolant: Interpolant type ('linear', 'cosine', 'vp') or instance.
+        model: Trained neural network predicting velocity/score/noise,
+            called as ``model(x, t, **model_kwargs)``.
+        mode: `"ode"` (probability flow, default) or `"sde"` (diffusion).
+        interpolant: Interpolant name ('linear', 'cosine', 'vp') or instance.
         prediction: Model prediction type ('velocity', 'score', or 'noise').
         train_eps: Epsilon used during training for time interval stability.
             Accepts a float or a `BaseScheduler`.
@@ -59,16 +86,22 @@ class FlowSampler(BaseSampler):
             `BaseScheduler` (advanced via `step_schedulers()`).
         negate_velocity: Negate the velocity during sampling. Set True for
             EqM models which learn (ε - x) direction; velocity is v = -f(x).
+        reverse: If True, integrate from data to noise (ODE mode only).
+        diffusion_form: SDE-only. Form of the diffusion coefficient:
+            'constant', 'SBDM' (default), 'sigma', 'linear', 'decreasing',
+            or 'increasing-decreasing'.
+        diffusion_norm: SDE-only. Scaling factor for diffusion (default 1.0).
+        last_step: SDE-only. Final denoising step: 'Mean' (default),
+            'Euler', 'Tweedie', or None (no correction).
+        last_step_size: SDE-only. Size of the final step (default 0.04).
         dtype: Data type for computations.
         device: Device for computations.
-        integrator: Integrator used by `sample_ode`/`sample_sde`. `None`
-            (default) keeps the per-mode defaults (`Dopri5Integrator` for
-            ODE, `EulerMaruyamaIntegrator` for SDE); a registry name (e.g.
-            `"rk4"`) constructs that integrator with defaults; a
-            `BaseRungeKuttaIntegrator` instance is used as-is and must
-            match the sampler's device/dtype. SDE sampling additionally
-            requires a `BaseSDERungeKuttaIntegrator`; SDE integrators are
-            valid for ODE sampling (zero diffusion).
+        integrator: `None` (default) uses `Dopri5Integrator` for ODE mode
+            and `EulerMaruyamaIntegrator` for SDE mode; a registry name
+            (e.g. `"rk4"`) constructs that integrator with defaults; an
+            instance is used as-is and must match the sampler's
+            device/dtype. SDE mode requires a `BaseSDERungeKuttaIntegrator`;
+            SDE integrators are valid for ODE mode (zero diffusion).
 
     Example:
         ```python
@@ -83,128 +116,110 @@ class FlowSampler(BaseSampler):
             prediction="velocity",
             integrator="euler",
         )
-        z = torch.randn(100, 2)
-        samples = sampler.sample_ode(z, num_steps=50)
+        samples = sampler.sample(n_samples=100, dim=2, n_steps=50)
         ```
     """
 
     def __init__(
         self,
         model: nn.Module,
+        mode: Literal["ode", "sde"] = "ode",
         interpolant: Union[str, BaseInterpolant] = "linear",
         prediction: Literal["velocity", "score", "noise"] = "velocity",
         train_eps: Union[float, BaseScheduler] = 0.0,
         sample_eps: Union[float, BaseScheduler] = 0.0,
         negate_velocity: bool = False,
+        reverse: bool = False,
+        diffusion_form: Optional[str] = None,
+        diffusion_norm: Optional[float] = None,
+        last_step: Union[str, None, object] = _UNSET,
+        last_step_size: Optional[float] = None,
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
         integrator: Union[str, BaseRungeKuttaIntegrator, None] = None,
-        *args,
-        **kwargs,
     ):
-        super().__init__(
-            model=model,
-            dtype=dtype,
-            device=device,
-        )
+        super().__init__(model=model, dtype=dtype, device=device)
         self._register_param("train_eps", train_eps)
         self._register_param("sample_eps", sample_eps)
         self.negate_velocity = negate_velocity
 
-        if isinstance(interpolant, str):
-            self.interpolant = get_interpolant(interpolant)
-        else:
-            self.interpolant = interpolant
+        if mode not in ("ode", "sde"):
+            raise ValueError(f"Unknown mode: {mode!r}. Choose from ['ode', 'sde']")
+        self.mode = mode
+
+        # Interpolants are stateless math objects (no device-bound tensors).
+        self.interpolant = resolve_interpolant(
+            interpolant, default="linear", owner="FlowSampler"
+        )
 
         prediction_map = {
             "velocity": PredictionType.VELOCITY,
             "score": PredictionType.SCORE,
             "noise": PredictionType.NOISE,
         }
-        self.prediction_type = prediction_map[prediction]
-        # Interpolants are stateless math objects (no device-bound tensors).
+        try:
+            self.prediction_type = prediction_map[prediction]
+        except KeyError:
+            raise ValueError(
+                f"Unknown prediction: {prediction!r}. "
+                f"Choose from {list(prediction_map)}"
+            ) from None
 
-        if integrator is None:
-            # Per-mode defaults; resolved by _integrator_for at call time.
-            self.integrator = None
-            self._ode_default = get_integrator(
-                "dopri5", device=self.device, dtype=self.dtype
-            )
-            self._sde_default = get_integrator(
-                "euler_maruyama", device=self.device, dtype=self.dtype
-            )
+        if mode == "ode":
+            offenders = [
+                name
+                for name, value in (
+                    ("diffusion_form", diffusion_form),
+                    ("diffusion_norm", diffusion_norm),
+                    ("last_step_size", last_step_size),
+                )
+                if value is not None
+            ]
+            if last_step is not _UNSET:
+                offenders.append("last_step")
+            if offenders:
+                raise ValueError(
+                    f"{', '.join(sorted(offenders))} only apply to mode='sde'"
+                )
+            self.diffusion_form = None
+            self.diffusion_norm = None
+            self.last_step = None
+            self.last_step_size = None
         else:
-            self.integrator = resolve_integrator(
-                integrator,
-                default="dopri5",
-                family=BaseRungeKuttaIntegrator,
-                owner="FlowSampler",
-                device=self.device,
-                dtype=self.dtype,
+            if reverse:
+                raise ValueError("reverse=True is not supported for mode='sde'")
+            self.diffusion_form = (
+                diffusion_form if diffusion_form is not None else "SBDM"
             )
-            self._ode_default = None
-            self._sde_default = None
+            self.diffusion_norm = diffusion_norm if diffusion_norm is not None else 1.0
+            self.last_step = "Mean" if last_step is _UNSET else last_step
+            if self.last_step not in _LAST_STEPS:
+                raise ValueError(
+                    f"Unknown last_step: {self.last_step!r}. "
+                    f"Choose from {list(_LAST_STEPS)}"
+                )
+            self.last_step_size = last_step_size if last_step_size is not None else 0.04
+            if self.last_step is None:
+                self.last_step_size = 0.0
+        self.reverse = reverse
 
-    def _integrator_for(
-        self,
-        mode: Literal["ode", "sde"],
-        integ: Optional[BaseRungeKuttaIntegrator] = None,
-    ) -> BaseRungeKuttaIntegrator:
-        r"""Return the integrator to use for ``mode``, validated.
-
-        Args:
-            mode: `"ode"` or `"sde"`.
-            integ: Pre-resolved integrator (deprecated per-call path).
-                `None` uses the constructor integrator or the mode default.
-
-        Raises:
-            TypeError: If SDE sampling is requested with an integrator that
-                cannot handle diffusion.
-        """
-        if integ is None:
-            integ = self.integrator
-        if integ is None:
-            integ = self._ode_default if mode == "ode" else self._sde_default
-        if mode == "sde" and not isinstance(integ, BaseSDERungeKuttaIntegrator):
-            raise TypeError(
-                "SDE sampling requires a BaseSDERungeKuttaIntegrator; got "
-                f"{type(integ).__name__}"
-            )
-        return integ
-
-    def _deprecated_call_integrator(
-        self,
-        mode: Literal["ode", "sde"],
-        method: Optional[str],
-        atol: Optional[float] = None,
-        rtol: Optional[float] = None,
-    ) -> Optional[BaseRungeKuttaIntegrator]:
-        r"""Resolve the deprecated per-call ``method``/``atol``/``rtol`` args.
-
-        Returns `None` when no deprecated argument was given.
-        """
-        if method is None and atol is None and rtol is None:
-            return None
-        warnings.warn(
-            "method/atol/rtol on FlowSampler sampling calls are deprecated; "
-            "pass integrator= to the FlowSampler constructor (atol/rtol are "
-            "set on the integrator instance).",
-            # 4 frames: helper -> sample_ode/sample_sde -> torch.no_grad
-            # wrapper -> caller.
-            DeprecationWarning,
-            stacklevel=4,
+        family = (
+            BaseRungeKuttaIntegrator if mode == "ode" else BaseSDERungeKuttaIntegrator
         )
-        default = "dopri5" if mode == "ode" else "euler_maruyama"
-        integ = get_integrator(
-            method if method is not None else default,
+        self.integrator = resolve_integrator(
+            integrator,
+            default="dopri5" if mode == "ode" else "euler_maruyama",
+            family=family,
+            owner="FlowSampler",
             device=self.device,
             dtype=self.dtype,
         )
-        if atol is not None:
-            integ.atol = atol
-        if rtol is not None:
-            integ.rtol = rtol
-        return integ
+        if mode == "sde" and self.integrator.error_weights is not None:
+            raise ValueError(
+                "Adaptive integrators are ODE-only; mode='sde' requires a "
+                f"fixed-step integrator, got {type(self.integrator).__name__}"
+            )
+        self._default_n_steps = 50 if mode == "ode" else 250
 
     @property
     def train_eps(self) -> float:
@@ -221,90 +236,6 @@ class FlowSampler(BaseSampler):
     @sample_eps.setter
     def sample_eps(self, value: Union[float, BaseScheduler]) -> None:
         self._register_param("sample_eps", value)
-
-    @torch.no_grad()
-    def sample(
-        self,
-        x: Optional[torch.Tensor] = None,
-        dim: int = 10,
-        n_steps: int = 50,
-        n_samples: int = 1,
-        thin: int = 1,
-        return_trajectory: bool = False,
-        return_diagnostics: bool = False,
-        reset_schedulers: bool = True,
-        *,
-        mode: Literal["ode", "sde"] = "ode",
-        shape: Optional[Tuple[int, ...]] = None,
-        ode_method: Optional[str] = None,
-        atol: Optional[float] = None,
-        rtol: Optional[float] = None,
-        reverse: bool = False,
-        sde_method: Optional[str] = None,
-        diffusion_form: str = "SBDM",
-        diffusion_norm: float = 1.0,
-        last_step: Optional[str] = "Mean",
-        last_step_size: float = 0.04,
-        **model_kwargs,
-    ) -> torch.Tensor:
-        r"""Unified sampling entrypoint for flow/diffusion models.
-
-        Conforms to the `BaseSampler.sample` contract for the common kwargs.
-        Flow-specific options (`mode`, `reverse`, diffusion settings) are
-        keyword-only. For full control, call `sample_ode` or `sample_sde`
-        directly. The integrator is set at construction via the
-        ``integrator`` argument; `ode_method`/`sde_method`/`atol`/`rtol`
-        are deprecated per-call overrides.
-
-        ``thin``, ``return_trajectory``, and ``return_diagnostics`` are not
-        supported by ODE/SDE solvers (they integrate continuously, not stepwise);
-        passing non-default values raises `NotImplementedError`. ``reset_schedulers``
-        is honored for `train_eps` / `sample_eps` schedules.
-
-        Raises:
-            NotImplementedError: If `thin != 1`, `return_trajectory=True`, or
-                `return_diagnostics=True`.
-            ValueError: If `mode` is not `"ode"` or `"sde"`.
-        """
-        if thin != 1:
-            raise NotImplementedError("thin is not supported for FlowSampler")
-        if return_trajectory or return_diagnostics:
-            raise NotImplementedError(
-                "FlowSampler does not support trajectories/diagnostics"
-            )
-        if reset_schedulers:
-            self.reset_schedulers()
-
-        if x is None:
-            if shape is not None:
-                z = torch.randn(*shape, device=self.device, dtype=self.dtype)
-            else:
-                z = torch.randn(n_samples, dim, device=self.device, dtype=self.dtype)
-        else:
-            z = x.to(device=self.device, dtype=self.dtype)
-
-        if mode == "ode":
-            return self.sample_ode(
-                z=z,
-                num_steps=n_steps,
-                method=ode_method,
-                atol=atol,
-                rtol=rtol,
-                reverse=reverse,
-                **model_kwargs,
-            )
-        if mode == "sde":
-            return self.sample_sde(
-                z=z,
-                num_steps=n_steps,
-                method=sde_method,
-                diffusion_form=diffusion_form,
-                diffusion_norm=diffusion_norm,
-                last_step=last_step,
-                last_step_size=last_step_size,
-                **model_kwargs,
-            )
-        raise ValueError(f"Unknown mode: {mode}")
 
     def _get_drift(self) -> Callable:
         r"""Get drift function for probability flow ODE."""
@@ -355,17 +286,13 @@ class FlowSampler(BaseSampler):
         }
         return scores[self.prediction_type]
 
-    def _check_interval(
-        self,
-        sde: bool = False,
-        reverse: bool = False,
-        last_step_size: float = 0.0,
-        diffusion_form: str = "SBDM",
-    ) -> Tuple[float, float]:
-        r"""Compute time interval for sampling."""
+    def _check_interval(self) -> Tuple[float, float]:
+        r"""Forward time interval `(t0, t1)` for the configured process."""
         t0 = 0.0
         t1 = 1.0
         eps = self.sample_eps
+        sde = self.mode == "sde"
+        last_step_size = self.last_step_size if sde else 0.0
 
         is_vp = isinstance(self.interpolant, VariancePreservingInterpolant)
         is_linear_or_cosine = isinstance(
@@ -379,174 +306,266 @@ class FlowSampler(BaseSampler):
         ):
             t0 = (
                 eps
-                if (diffusion_form == "SBDM" and sde)
+                if (self.diffusion_form == "SBDM" and sde)
                 or self.prediction_type != PredictionType.VELOCITY
                 else 0
             )
             t1 = 1 - eps if (not sde or last_step_size == 0) else 1 - last_step_size
 
-        if reverse:
-            t0, t1 = 1 - t0, 1 - t1
-
         return t0, t1
 
-    @torch.no_grad()
-    def sample_ode(
-        self,
-        z: torch.Tensor,
-        num_steps: int = 50,
-        method: Optional[str] = None,
-        atol: Optional[float] = None,
-        rtol: Optional[float] = None,
-        reverse: bool = False,
-        **model_kwargs,
-    ) -> torch.Tensor:
-        r"""
-        Sample using probability flow ODE.
+    def _grid_and_drift(
+        self, drift_fn: Callable, n_steps: int
+    ) -> Tuple[Callable, torch.Tensor, torch.Tensor]:
+        r"""Integration drift, grid, and physical model times per kept point.
 
-        The solver is the constructor ``integrator`` (default: adaptive
-        `Dopri5Integrator`).
-
-        Args:
-            z: Initial noise tensor of shape (batch_size, ...).
-            num_steps: Number of discretization steps (for fixed-step methods).
-            method: Deprecated. Pass ``integrator=`` to the constructor.
-            atol: Deprecated. Set on the integrator instance.
-            rtol: Deprecated. Set on the integrator instance.
-            reverse: If True, sample from data to noise.
-            **model_kwargs: Additional arguments passed to the model.
-
-        Returns:
-            Generated samples tensor.
+        Forward mode integrates ``dx/dt = f(x, t)`` on ``[t0, t1]``. Reverse
+        mode applies the change of variables ``s = t - t0``, integrating
+        ``dy/ds = -f(y, t0 + s)`` on ``[0, t1 - t0]``; this single form
+        serves fixed-step and adaptive integrators alike. The returned
+        ``t_phys`` is the interpolant time at each grid point (identical in
+        both modes).
         """
-        z = z.to(device=self.device, dtype=self.dtype)
-        integ = self._integrator_for(
-            "ode", self._deprecated_call_integrator("ode", method, atol, rtol)
+        t0, t1 = self._check_interval()
+        t_phys = torch.linspace(
+            t0, t1, n_steps + 1, device=self.device, dtype=self.dtype
         )
-        drift_fn = self._get_drift()
+        if not self.reverse:
+            return drift_fn, t_phys, t_phys
 
-        t0, t1 = self._check_interval(sde=False, reverse=reverse)
-        # num_steps is the number of integration steps, so we need num_steps+1 time points
-        t = torch.linspace(t0, t1, num_steps + 1, device=self.device, dtype=self.dtype)
+        def reversed_drift(x, s):
+            return -drift_fn(x, t0 + s)
 
-        if reverse:
+        grid = t_phys - t0
+        return reversed_drift, grid, t_phys
 
-            def wrapped_drift(x, t_val, **kwargs):
-                return drift_fn(x, 1.0 - t_val, **kwargs)
+    def _sde_dynamics(self) -> Tuple[Callable, Callable]:
+        r"""Reverse-SDE drift and diffusion callables.
 
-        else:
-            wrapped_drift = drift_fn
-
-        def fixed_step_drift(x, t_batch):
-            return wrapped_drift(x, t_batch, **model_kwargs)
-
-        drift = fixed_step_drift
-        if t1 < t0 and integ.error_weights is not None:
-            # Adaptive stepping assumes increasing time. Integrate the
-            # exact change of variables s = t0 - t on a forward grid;
-            # fixed-step integrators handle the raw decreasing grid.
-            def reversed_drift(x, s_batch):
-                return -fixed_step_drift(x, t0 - s_batch)
-
-            drift = reversed_drift
-            t = torch.linspace(
-                0.0, t0 - t1, num_steps + 1, device=self.device, dtype=self.dtype
-            )
-
-        return integ.integrate(
-            state={"x": z},
-            step_size=t[1] - t[0],
-            n_steps=num_steps,
-            drift=drift,
-            t=t,
-        )["x"]
-
-    @torch.no_grad()
-    def sample_sde(
-        self,
-        z: torch.Tensor,
-        num_steps: int = 250,
-        method: Optional[str] = None,
-        diffusion_form: str = "SBDM",
-        diffusion_norm: float = 1.0,
-        last_step: Optional[str] = "Mean",
-        last_step_size: float = 0.04,
-        **model_kwargs,
-    ) -> torch.Tensor:
-        r"""
-        Sample using reverse-time SDE.
-
-        The solver is the constructor ``integrator`` (default:
-        `EulerMaruyamaIntegrator`) and must be a
-        `BaseSDERungeKuttaIntegrator`.
-
-        Args:
-            z: Initial noise tensor of shape (batch_size, ...).
-            num_steps: Number of discretization steps.
-            method: Deprecated. Pass ``integrator=`` to the constructor.
-            diffusion_form: Form of diffusion coefficient. Choices:
-                - 'constant': Constant diffusion
-                - 'SBDM': Score-based diffusion matching (default)
-                - 'sigma': Proportional to noise schedule
-                - 'linear': Linear decay
-                - 'decreasing': Faster decay towards t=1
-                - 'increasing-decreasing': Peak at midpoint
-            diffusion_norm: Scaling factor for diffusion.
-            last_step: Type of last step ('Mean', 'Tweedie', 'Euler', or None).
-            last_step_size: Size of the last step.
-            **model_kwargs: Additional arguments passed to the model.
-
-        Returns:
-            Generated samples tensor.
+        The diffusion coefficient enters twice by design: as the score
+        correction inside the drift and as the Wiener noise magnitude.
         """
-        z = z.to(device=self.device, dtype=self.dtype)
-
-        if last_step is None:
-            last_step_size = 0.0
-
-        t0, t1 = self._check_interval(
-            sde=True, last_step_size=last_step_size, diffusion_form=diffusion_form
-        )
-        # t needs num_steps+1 points to perform num_steps integration steps
-        t = torch.linspace(t0, t1, num_steps + 1, device=self.device, dtype=self.dtype)
-
         drift_fn = self._get_drift()
         score_fn = self._get_score()
 
-        def diffusion_fn(x, t_val):
+        def diffusion_fn(x, t):
             return self.interpolant.compute_diffusion(
-                x, t_val, form=diffusion_form, norm=diffusion_norm
+                x, t, form=self.diffusion_form, norm=self.diffusion_norm
             )
 
-        def sde_drift(x, t_val, **kwargs):
-            diffusion = diffusion_fn(x, t_val)
-            return drift_fn(x, t_val, **kwargs) + diffusion * score_fn(
-                x, t_val, **kwargs
+        def sde_drift(x, t, **model_kwargs):
+            diffusion = diffusion_fn(x, t)
+            return drift_fn(x, t, **model_kwargs) + diffusion * score_fn(
+                x, t, **model_kwargs
             )
 
-        def fixed_sde_drift(x, t_val):
-            return sde_drift(x, t_val, **model_kwargs)
+        return sde_drift, diffusion_fn
 
-        integ = self._integrator_for(
-            "sde", self._deprecated_call_integrator("sde", method)
-        )
-        x = integ.integrate(
-            state={"x": z},
-            step_size=t[1] - t[0],
-            n_steps=num_steps,
-            drift=fixed_sde_drift,
-            diffusion=diffusion_fn,
-            t=t,
-        )["x"]
+    @torch.no_grad()
+    def sample(
+        self,
+        x: Optional[torch.Tensor] = None,
+        dim: Optional[Union[int, Tuple[int, ...]]] = None,
+        n_steps: Optional[int] = None,
+        n_samples: int = 1,
+        thin: int = 1,
+        return_trajectory: bool = False,
+        return_diagnostics: bool = False,
+        reset_schedulers: bool = True,
+        **model_kwargs,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
+        r"""Sample by integrating the configured ODE or SDE.
 
-        # Apply last step
-        if last_step is not None:
-            t_final = torch.ones(x.size(0), device=self.device, dtype=self.dtype) * t1
+        Args:
+            x: Initial state (typically noise). If `None`, samples from
+                `N(0, I)`.
+            dim: State dimension (int) or shape (tuple), used when `x is None`.
+            n_steps: Number of integration steps. `None` (default) resolves
+                to 50 in ODE mode and 250 in SDE mode. For adaptive
+                integrators only the implied time interval matters.
+            n_samples: Number of parallel samples.
+            thin: Keep every `thin`-th step. Final stored length is
+                `n_steps // thin`. Must be `>= 1`. Fixed-step integrators only.
+            return_trajectory: If True, return the full kept trajectory of
+                shape `[n_samples, n_steps // thin, *data_shape]`. Fixed-step
+                integrators only. In SDE mode the final kept entry reflects
+                the `last_step` correction, so the trajectory ends at the
+                returned sample.
+            return_diagnostics: If True, also return a dict with keys
+                ``"mean"`` (`[n_kept, *data_shape]`), ``"var"``
+                (`[n_kept, *data_shape]`), and ``"t"`` (`[n_kept]`, the
+                interpolant time of each kept step). With an adaptive
+                integrator the dict has a single entry for the final state.
+            reset_schedulers: If True (default), reset registered schedulers.
+                Fixed-step sampling advances schedulers once per step;
+                adaptive integrators do not step them (the actual step count
+                is controller-dependent).
+            **model_kwargs (Any): Additional conditioning arguments forwarded
+                to the model.
+
+        Returns:
+            Sample tensor (or trajectory if `return_trajectory=True`),
+            optionally paired with the diagnostics dict.
+
+        Raises:
+            ValueError: If `thin < 1`, `n_steps <= 0`, or `x` and `dim` are
+                both `None`.
+            NotImplementedError: If `return_trajectory=True` or `thin != 1`
+                with an adaptive integrator.
+            TypeError: If a removed legacy sampling kwarg is passed.
+        """
+        removed = _REMOVED_SAMPLE_KWARGS.intersection(model_kwargs)
+        if removed:
+            raise TypeError(
+                f"{', '.join(sorted(removed))}: removed from "
+                "FlowSampler.sample(). mode/reverse/diffusion/"
+                "last-step options and the integrator moved to the "
+                "constructor; use x/n_steps instead of z/num_steps and "
+                "dim=(...) instead of shape."
+            )
+        if thin < 1:
+            raise ValueError("thin must be >= 1")
+        if n_steps is None:
+            n_steps = self._default_n_steps
+        if n_steps <= 0:
+            raise ValueError("n_steps must be positive")
+        adaptive = self.integrator.error_weights is not None
+        if adaptive and (return_trajectory or thin != 1):
+            raise NotImplementedError(
+                "return_trajectory/thin require a fixed-step integrator; "
+                f"adaptive {type(self.integrator).__name__} returns only the "
+                "final state. Construct FlowSampler(integrator='euler') or "
+                "another fixed-step method."
+            )
+        if reset_schedulers:
+            self.reset_schedulers()
+
+        x = self._init_state(x, dim, n_samples)
+        n_samples = x.shape[0]
+        data_shape = x.shape[1:]
+
+        sde = self.mode == "sde"
+        if sde:
+            sde_drift, diffusion_fn = self._sde_dynamics()
+
+            def base_drift(x_, t_):
+                return sde_drift(x_, t_, **model_kwargs)
+
+        else:
+            drift_fn = self._get_drift()
+
+            def base_drift(x_, t_):
+                return drift_fn(x_, t_, **model_kwargs)
+
+        drift, grid, t_phys = self._grid_and_drift(base_drift, n_steps)
+
+        if adaptive:
+            with self.autocast_context():
+                x = self.integrator.integrate(
+                    state={"x": x},
+                    step_size=grid[1] - grid[0],
+                    n_steps=n_steps,
+                    drift=drift,
+                    t=grid,
+                )["x"]
+            if not return_diagnostics:
+                return x
+            return x, self._batch_stats(x, t_phys[-1:])
+
+        n_kept = n_steps // thin
+        if return_trajectory:
+            trajectory = torch.empty(
+                (n_samples, n_kept, *data_shape), dtype=self.dtype, device=self.device
+            )
+        diagnostics: Optional[Dict[str, torch.Tensor]] = None
+        if return_diagnostics:
+            diagnostics = {
+                "mean": torch.empty(
+                    n_kept, *data_shape, dtype=self.dtype, device=self.device
+                ),
+                "var": torch.empty(
+                    n_kept, *data_shape, dtype=self.dtype, device=self.device
+                ),
+                "t": torch.empty(n_kept, dtype=self.dtype, device=self.device),
+            }
+
+        keep_idx = 0
+        with self.autocast_context():
+            for i in range(n_steps):
+                dt = grid[i + 1] - grid[i]
+                t_batch = grid[i].expand(n_samples)
+                if sde:
+                    diff_val = diffusion_fn(x, t_batch)
+                    x = self.integrator.step(
+                        state={"x": x},
+                        step_size=dt,
+                        drift=drift,
+                        diffusion=diff_val,
+                        t=t_batch,
+                    )["x"]
+                else:
+                    x = self.integrator.step(
+                        state={"x": x}, step_size=dt, drift=drift, t=t_batch
+                    )["x"]
+                self.step_schedulers()
+
+                if (i + 1) % thin == 0:
+                    if return_trajectory:
+                        trajectory[:, keep_idx] = x
+                    if return_diagnostics:
+                        self._record_stats(diagnostics, keep_idx, x, t_phys[i + 1])
+                    keep_idx += 1
+
+        if sde and self.last_step is not None:
+            t1 = t_phys[-1]
+            t_final = t1.expand(n_samples)
             x = self._apply_last_step(
-                x, t_final, sde_drift, last_step, last_step_size, **model_kwargs
+                x,
+                t_final,
+                sde_drift,
+                self.last_step,
+                self.last_step_size,
+                **model_kwargs,
             )
+            # Keep the recorded end state equal to the returned sample.
+            if n_kept > 0 and n_steps % thin == 0:
+                if return_trajectory:
+                    trajectory[:, -1] = x
+                if return_diagnostics:
+                    self._record_stats(
+                        diagnostics, n_kept - 1, x, t1 + self.last_step_size
+                    )
 
-        return x
+        output = trajectory if return_trajectory else x
+        return (output, diagnostics) if return_diagnostics else output
+
+    def _record_stats(
+        self,
+        diagnostics: Dict[str, torch.Tensor],
+        keep_idx: int,
+        x: torch.Tensor,
+        t: Union[float, torch.Tensor],
+    ) -> None:
+        r"""Record batch mean/var and the interpolant time at a kept step."""
+        if x.shape[0] > 1:
+            diagnostics["mean"][keep_idx] = x.mean(dim=0)
+            diagnostics["var"][keep_idx] = x.var(dim=0, unbiased=False).clamp_(
+                min=1e-10, max=1e10
+            )
+        else:
+            diagnostics["mean"][keep_idx] = x.squeeze(0)
+            diagnostics["var"][keep_idx].zero_()
+        diagnostics["t"][keep_idx] = t
+
+    def _batch_stats(self, x: torch.Tensor, t: torch.Tensor) -> Dict[str, torch.Tensor]:
+        r"""Single-entry diagnostics for the final state (adaptive path)."""
+        diagnostics = {
+            "mean": torch.empty(1, *x.shape[1:], dtype=self.dtype, device=self.device),
+            "var": torch.empty(1, *x.shape[1:], dtype=self.dtype, device=self.device),
+            "t": torch.empty(1, dtype=self.dtype, device=self.device),
+        }
+        self._record_stats(diagnostics, 0, x, t[0])
+        return diagnostics
 
     def _apply_last_step(
         self,
@@ -576,7 +595,7 @@ class FlowSampler(BaseSampler):
         r"""Compute log probability under standard Gaussian prior."""
         N = z[0].numel()
         return (
-            -N / 2.0 * np.log(2 * np.pi)
+            -N / 2.0 * math.log(2 * math.pi)
             - torch.sum(z.square(), dim=tuple(range(1, z.ndim))) / 2.0
         )
 

--- a/torchebm/samplers/gradient_descent.py
+++ b/torchebm/samplers/gradient_descent.py
@@ -50,8 +50,6 @@ class GradientDescentSampler(BaseSampler):
         step_size: Union[float, BaseScheduler] = 1e-3,
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
-        *args,
-        **kwargs,
     ):
         super().__init__(
             model=model,
@@ -64,21 +62,19 @@ class GradientDescentSampler(BaseSampler):
     def sample(
         self,
         x: Optional[torch.Tensor] = None,
-        dim: int = 10,
+        dim: Optional[Union[int, Tuple[int, ...]]] = None,
         n_steps: int = 100,
         n_samples: int = 1,
         thin: int = 1,
         return_trajectory: bool = False,
         return_diagnostics: bool = False,
         reset_schedulers: bool = True,
-        *args,
-        **kwargs,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
         r"""Generate samples via gradient descent optimization.
 
         Args:
             x: Initial state. If None, samples from N(0, I).
-            dim: Dimension of state space (used if x is None).
+            dim: State dimension (int) or shape (tuple), used when `x is None`.
             n_steps: Number of gradient descent steps.
             n_samples: Number of parallel chains/samples.
             thin: Keep every `thin`-th sample. Final length `n_steps // thin`.
@@ -89,17 +85,14 @@ class GradientDescentSampler(BaseSampler):
             reset_schedulers: If True (default), reset registered schedulers.
 
         Raises:
-            ValueError: If `thin < 1`.
+            ValueError: If `thin < 1`, or if `x` and `dim` are both `None`.
         """
         if thin < 1:
             raise ValueError("thin must be >= 1")
         if reset_schedulers:
             self.reset_schedulers()
 
-        if x is None:
-            x = torch.randn(n_samples, dim, device=self.device, dtype=self.dtype)
-        else:
-            x = x.to(device=self.device, dtype=self.dtype)
+        x = self._init_state(x, dim, n_samples)
 
         n_kept = n_steps // thin
         if return_trajectory:
@@ -176,8 +169,6 @@ class NesterovSampler(BaseSampler):
         momentum: float = 0.9,
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
-        *args,
-        **kwargs,
     ):
         super().__init__(
             model=model,
@@ -194,21 +185,19 @@ class NesterovSampler(BaseSampler):
     def sample(
         self,
         x: Optional[torch.Tensor] = None,
-        dim: int = 10,
+        dim: Optional[Union[int, Tuple[int, ...]]] = None,
         n_steps: int = 100,
         n_samples: int = 1,
         thin: int = 1,
         return_trajectory: bool = False,
         return_diagnostics: bool = False,
         reset_schedulers: bool = True,
-        *args,
-        **kwargs,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
         r"""Generate samples via Nesterov accelerated gradient descent.
 
         Args:
             x: Initial state. If None, samples from N(0, I).
-            dim: Dimension of state space (used if x is None).
+            dim: State dimension (int) or shape (tuple), used when `x is None`.
             n_steps: Number of optimization steps.
             n_samples: Number of parallel chains/samples.
             thin: Keep every `thin`-th sample. Final length `n_steps // thin`.
@@ -219,17 +208,14 @@ class NesterovSampler(BaseSampler):
             reset_schedulers: If True (default), reset registered schedulers.
 
         Raises:
-            ValueError: If `thin < 1`.
+            ValueError: If `thin < 1`, or if `x` and `dim` are both `None`.
         """
         if thin < 1:
             raise ValueError("thin must be >= 1")
         if reset_schedulers:
             self.reset_schedulers()
 
-        if x is None:
-            x = torch.randn(n_samples, dim, device=self.device, dtype=self.dtype)
-        else:
-            x = x.to(device=self.device, dtype=self.dtype)
+        x = self._init_state(x, dim, n_samples)
 
         v = torch.zeros_like(x)
         n_kept = n_steps // thin

--- a/torchebm/samplers/hmc.py
+++ b/torchebm/samplers/hmc.py
@@ -59,8 +59,6 @@ class HamiltonianMonteCarlo(BaseSampler):
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
         integrator: Union[str, BaseSymplecticIntegrator, None] = None,
-        *args,
-        **kwargs,
     ):
         super().__init__(model=model, dtype=dtype, device=device)
         self._register_param("step_size", step_size, positive=True)
@@ -192,19 +190,16 @@ class HamiltonianMonteCarlo(BaseSampler):
         if reset_schedulers:
             self.reset_schedulers()
 
-        if x is None:
-            if dim is None:
-                if hasattr(self.model, "mean") and isinstance(
-                    self.model.mean, torch.Tensor
-                ):
-                    dim = self.model.mean.shape[0]
-                else:
-                    raise ValueError(
-                        "dim must be provided when x is None and cannot be inferred from model"
-                    )
-            x = torch.randn(n_samples, dim, dtype=self.dtype, device=self.device)
-        else:
-            x = x.to(device=self.device, dtype=self.dtype)
+        if x is None and dim is None:
+            if hasattr(self.model, "mean") and isinstance(
+                self.model.mean, torch.Tensor
+            ):
+                dim = self.model.mean.shape[0]
+            else:
+                raise ValueError(
+                    "dim must be provided when x is None and cannot be inferred from model"
+                )
+        x = self._init_state(x, dim, n_samples)
 
         dim = x.shape[1]
         batch_size = x.shape[0]
@@ -376,8 +371,6 @@ class RiemannianManifoldHMC(BaseSampler):
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
         integrator: Union[str, BaseSymplecticIntegrator, None] = None,
-        *args,
-        **kwargs,
     ):
         super().__init__(model=model, dtype=dtype, device=device)
         if not callable(metric_fn):
@@ -409,8 +402,10 @@ class RiemannianManifoldHMC(BaseSampler):
                 DeprecationWarning,
                 stacklevel=2,
             )
-        if integrator is None:
-            self.integrator = GeneralisedLeapfrogIntegrator(
+        if solver_kwargs_given:
+            # Deprecated path (integrator= excluded above): thread the old
+            # solver options into a directly constructed integrator.
+            integ = GeneralisedLeapfrogIntegrator(
                 device=self.device,
                 dtype=self.dtype,
                 solver_max_iter=(
@@ -430,14 +425,14 @@ class RiemannianManifoldHMC(BaseSampler):
                 device=self.device,
                 dtype=self.dtype,
             )
-            if integ.separable:
-                raise TypeError(
-                    "RiemannianManifoldHMC requires a non-separable "
-                    "symplectic integrator (force/velocity contract); got "
-                    f"separable {type(integ).__name__}. Use "
-                    "HamiltonianMonteCarlo for separable Hamiltonians."
-                )
-            self.integrator = integ
+        if integ.separable:
+            raise TypeError(
+                "RiemannianManifoldHMC requires a non-separable "
+                "symplectic integrator (force/velocity contract); got "
+                f"separable {type(integ).__name__}. Use "
+                "HamiltonianMonteCarlo for separable Hamiltonians."
+            )
+        self.integrator = integ
 
     @staticmethod
     def _cholesky(G: torch.Tensor) -> torch.Tensor:
@@ -581,20 +576,17 @@ class RiemannianManifoldHMC(BaseSampler):
         if reset_schedulers:
             self.reset_schedulers()
 
-        if x is None:
-            if dim is None:
-                if hasattr(self.model, "mean") and isinstance(
-                    self.model.mean, torch.Tensor
-                ):
-                    dim = self.model.mean.shape[0]
-                else:
-                    raise ValueError(
-                        "dim must be provided when x is None and cannot be "
-                        "inferred from model"
-                    )
-            x = torch.randn(n_samples, dim, dtype=self.dtype, device=self.device)
-        else:
-            x = x.to(device=self.device, dtype=self.dtype)
+        if x is None and dim is None:
+            if hasattr(self.model, "mean") and isinstance(
+                self.model.mean, torch.Tensor
+            ):
+                dim = self.model.mean.shape[0]
+            else:
+                raise ValueError(
+                    "dim must be provided when x is None and cannot be "
+                    "inferred from model"
+                )
+        x = self._init_state(x, dim, n_samples)
 
         if x.ndim != 2:
             raise ValueError(

--- a/torchebm/samplers/langevin_dynamics.py
+++ b/torchebm/samplers/langevin_dynamics.py
@@ -60,8 +60,6 @@ class LangevinDynamics(BaseSampler):
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
         integrator: Union[str, BaseSDERungeKuttaIntegrator, None] = None,
-        *args,
-        **kwargs,
     ):
         super().__init__(model=model, dtype=dtype, device=device)
 
@@ -85,30 +83,28 @@ class LangevinDynamics(BaseSampler):
     def sample(
         self,
         x: Optional[torch.Tensor] = None,
-        dim: int = 10,
+        dim: Optional[Union[int, Tuple[int, ...]]] = None,
         n_steps: int = 100,
         n_samples: int = 1,
         thin: int = 1,
         return_trajectory: bool = False,
         return_diagnostics: bool = False,
         reset_schedulers: bool = True,
-        *args,
-        **kwargs,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
         r"""Generate samples via Langevin dynamics.
 
         Args:
             x: Initial state. If `None`, samples from `N(0, I)`.
-            dim: State-space dimension (used when `x is None`).
+            dim: State dimension (int) or shape (tuple), used when `x is None`.
             n_steps: Number of MCMC steps to perform.
             n_samples: Number of parallel chains to generate.
             thin: Keep every `thin`-th sample. Final stored length is
                 `n_steps // thin`. Must be `>= 1`.
             return_trajectory: If True, return the full kept trajectory of shape
-                `[n_samples, n_steps // thin, dim]`.
+                `[n_samples, n_steps // thin, *data_shape]`.
             return_diagnostics: If True, also return a dict with keys
-                ``"mean"`` (`[n_kept, dim]`), ``"var"`` (`[n_kept, dim]`), and
-                ``"energy"`` (`[n_kept]`).
+                ``"mean"`` (`[n_kept, *data_shape]`), ``"var"``
+                (`[n_kept, *data_shape]`), and ``"energy"`` (`[n_kept]`).
             reset_schedulers: If True (default), reset registered schedulers.
 
         Returns:
@@ -116,32 +112,33 @@ class LangevinDynamics(BaseSampler):
             optionally paired with the diagnostics dict.
 
         Raises:
-            ValueError: If `thin < 1`.
+            ValueError: If `thin < 1`, or if `x` and `dim` are both `None`.
         """
         if thin < 1:
             raise ValueError("thin must be >= 1")
         if reset_schedulers:
             self.reset_schedulers()
 
-        if x is None:
-            x = torch.randn(n_samples, dim, dtype=self.dtype, device=self.device)
-        else:
-            x = x.to(device=self.device, dtype=self.dtype)
-            dim = x.shape[-1]
-            n_samples = x.shape[0]
+        x = self._init_state(x, dim, n_samples)
+        n_samples = x.shape[0]
+        data_shape = x.shape[1:]
 
         n_kept = n_steps // thin
 
         if return_trajectory:
             trajectory = torch.empty(
-                (n_samples, n_kept, dim), dtype=self.dtype, device=self.device
+                (n_samples, n_kept, *data_shape), dtype=self.dtype, device=self.device
             )
 
         diagnostics: Optional[Dict[str, torch.Tensor]] = None
         if return_diagnostics:
             diagnostics = {
-                "mean": torch.empty(n_kept, dim, dtype=self.dtype, device=self.device),
-                "var": torch.empty(n_kept, dim, dtype=self.dtype, device=self.device),
+                "mean": torch.empty(
+                    n_kept, *data_shape, dtype=self.dtype, device=self.device
+                ),
+                "var": torch.empty(
+                    n_kept, *data_shape, dtype=self.dtype, device=self.device
+                ),
                 "energy": torch.empty(n_kept, dtype=self.dtype, device=self.device),
             }
 
@@ -162,7 +159,7 @@ class LangevinDynamics(BaseSampler):
 
                 if (i + 1) % thin == 0:
                     if return_trajectory:
-                        trajectory[:, keep_idx, :] = x
+                        trajectory[:, keep_idx] = x
                     if return_diagnostics:
                         if n_samples > 1:
                             diagnostics["mean"][keep_idx] = x.mean(dim=0)


### PR DESCRIPTION
FlowSampler is configured at the constructor (mode="ode"|"sde", reverse, diffusion options, integrator) and sample() now follows the same contract as every other sampler, including thin/trajectory/diagnostics on fixed-step integrators. Library-wide: dim accepts int or tuple, dead kwargs cascades dropped, interpolant registry moved next to the integrator one, resolve_integrator exported and hardened, and a cross-sampler contract test pins the API. Breaking changes and the migration table are in the changelog.

Resolves #170, resolves #171, resolves #172, resolves #173, resolves #174, resolves #175