### PR TITLE
Distributed shim and multi-process test harness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ testpaths = [
 ]
 markers = [
     "examples: smoke-runs the examples/ curriculum (deselected by default; run with -m examples)",
+    "distributed: multi-process torch.distributed tests (2-process gloo on CPU)",
 ]
 
 [tool.coverage.run]

--- a/tests/distributed/dist_harness.py
+++ b/tests/distributed/dist_harness.py
@@ -1,0 +1,104 @@
+r"""Spawn harness for the 2-process gloo/CPU distributed suite.
+
+Lessons this harness hard-codes (learned from the design spikes):
+
+- The DeviceMesh device heuristic silently picks cuda when a GPU is visible,
+  and two gloo CPU processes then drive one GPU and segfault inside functional
+  collectives. Children therefore hide CUDA, and meshes are created explicitly
+  on cpu via `cpu_mesh`.
+- Children run faulthandler into per-rank crash logs so a SIGSEGV still
+  produces a stack instead of a bare ProcessExitedException.
+
+Worker functions must be top-level in their test module (spawn pickles them by
+reference; children inherit sys.path, so pytest-imported test modules resolve).
+"""
+
+import faulthandler
+import os
+import tempfile
+import time
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+WORLD_SIZE = 2
+_TIMEOUT_S = 300.0
+
+
+def cpu_mesh(world_size: int = WORLD_SIZE):
+    r"""Explicit CPU device mesh; never rely on the device heuristic here."""
+    from torch.distributed.device_mesh import init_device_mesh
+
+    return init_device_mesh("cpu", (world_size,))
+
+
+def save_result(tmpdir: str, rank: int, obj) -> None:
+    r"""Persist a worker's result for the parent to load after join."""
+    torch.save(obj, os.path.join(tmpdir, f"result_rank{rank}.pt"))
+
+
+def _entry(rank, fn, world_size, tmpdir, args):
+    os.environ["CUDA_VISIBLE_DEVICES"] = ""
+    faulthandler.enable(open(os.path.join(tmpdir, f"crash_rank{rank}.log"), "w"))
+    torch.set_num_threads(1)
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{os.path.join(tmpdir, 'init')}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        fn(rank, world_size, tmpdir, *args)
+    finally:
+        dist.destroy_process_group()
+
+
+def _crash_logs(tmpdir: str, world_size: int) -> str:
+    parts = []
+    for r in range(world_size):
+        path = os.path.join(tmpdir, f"crash_rank{r}.log")
+        if os.path.exists(path):
+            with open(path) as f:
+                text = f.read().strip()
+            if text:
+                parts.append(f"--- rank {r} crash log ---\n{text}")
+    return "\n".join(parts)
+
+
+def spawn_dist(fn, world_size: int = WORLD_SIZE, timeout: float = _TIMEOUT_S, args=()):
+    r"""Run `fn(rank, world_size, tmpdir, *args)` on `world_size` gloo processes.
+
+    Returns the per-rank objects stored via `save_result` (None where a rank
+    saved nothing). Raises with the per-rank crash logs attached on child
+    failure or timeout.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        ctx = mp.start_processes(
+            _entry,
+            args=(fn, world_size, tmpdir, args),
+            nprocs=world_size,
+            join=False,
+            start_method="spawn",
+        )
+        try:
+            deadline = time.monotonic() + timeout
+            done = False
+            while not done:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise RuntimeError(
+                        f"distributed workers timed out after {timeout}s"
+                    )
+                done = ctx.join(remaining)
+        except Exception as e:
+            for p in ctx.processes:
+                if p.is_alive():
+                    p.terminate()
+            logs = _crash_logs(tmpdir, world_size)
+            raise RuntimeError(f"distributed workers failed: {e}\n{logs}") from e
+        results = []
+        for r in range(world_size):
+            path = os.path.join(tmpdir, f"result_rank{r}.pt")
+            results.append(torch.load(path) if os.path.exists(path) else None)
+        return results

--- a/tests/distributed/test_distributed_shim.py
+++ b/tests/distributed/test_distributed_shim.py
@@ -1,0 +1,45 @@
+r"""Shim behavior single-process and under a 2-process gloo group."""
+
+import sys
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from torchebm import distributed as ebm_dist
+
+from dist_harness import save_result, spawn_dist
+
+pytestmark = [
+    pytest.mark.distributed,
+    pytest.mark.skipif(not dist.is_available(), reason="torch.distributed unavailable"),
+    pytest.mark.skipif(sys.platform == "win32", reason="gloo spawn harness is POSIX-only"),
+]
+
+
+def test_single_process_identity():
+    assert not ebm_dist.is_distributed()
+    assert ebm_dist.get_rank() == 0
+    assert ebm_dist.get_world_size() == 1
+    x = torch.randn(4, 3)
+    assert ebm_dist.all_gather_cat(x) is x
+    obj = {"a": 1}
+    assert ebm_dist.broadcast_object(obj) is obj
+
+
+def _shim_worker(rank, world_size, tmpdir):
+    assert ebm_dist.is_distributed()
+    assert ebm_dist.get_rank() == rank
+    assert ebm_dist.get_world_size() == world_size
+    gathered = ebm_dist.all_gather_cat(torch.full((2, 3), float(rank)))
+    payload = ebm_dist.broadcast_object({"seed": 1234} if rank == 0 else None)
+    save_result(tmpdir, rank, {"gathered": gathered, "payload": payload})
+
+
+def test_shim_collectives_two_ranks():
+    results = spawn_dist(_shim_worker)
+    world = len(results)
+    expected = torch.cat([torch.full((2, 3), float(r)) for r in range(world)])
+    for res in results:
+        assert torch.equal(res["gathered"], expected)
+        assert res["payload"] == {"seed": 1234}

--- a/tests/distributed/test_fsdp2_score_matching.py
+++ b/tests/distributed/test_fsdp2_score_matching.py
@@ -1,0 +1,140 @@
+r"""Pins the FSDP2 facts the distributed score-matching contract is built on.
+
+1. The hook path (`fully_shard` wrappers) cannot run the double backward that
+   score matching needs: the post-backward hook reshards parameter storage the
+   second-order graph still references, independent of `reshard_after_forward`.
+   If torch ever lifts this, the failure test breaks loudly and the
+   functional-path requirement can be revisited.
+2. The functional path (`functional_call` on a hook-free skeleton with the
+   sharded DTensor params and a batch-sharded input) runs the double backward
+   through differentiable DTensor collectives and reproduces the gradients of
+   an unsharded reference with global-batch-mean semantics.
+"""
+
+import copy
+import sys
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch import nn
+
+from dist_harness import cpu_mesh, save_result, spawn_dist
+
+fsdp = pytest.importorskip("torch.distributed.fsdp")
+
+pytestmark = [
+    pytest.mark.distributed,
+    pytest.mark.skipif(not dist.is_available(), reason="torch.distributed unavailable"),
+    pytest.mark.skipif(sys.platform == "win32", reason="gloo spawn harness is POSIX-only"),
+    pytest.mark.skipif(not hasattr(fsdp, "fully_shard"), reason="FSDP2 unavailable"),
+]
+
+DIM = 8
+BATCH = 8
+NOISE = 0.1
+
+
+def _make_net():
+    return nn.Sequential(
+        nn.Linear(DIM, 16), nn.SiLU(), nn.Linear(16, 16), nn.SiLU(), nn.Linear(16, 1)
+    )
+
+
+def _hook_path_worker(rank, world_size, tmpdir):
+    from torchebm.core import BaseModel
+    from torchebm.losses import DenoisingScoreMatching
+
+    class MLPEnergy(BaseModel):
+        def __init__(self):
+            super().__init__()
+            self.net = _make_net()
+
+        def forward(self, x):
+            return self.net(x).squeeze(-1)
+
+    torch.manual_seed(0)
+    model = MLPEnergy()
+    mesh = cpu_mesh(world_size)
+    for m in model.net:
+        if isinstance(m, nn.Linear):
+            fsdp.fully_shard(m, mesh=mesh)
+    fsdp.fully_shard(model.net, mesh=mesh)
+
+    torch.manual_seed(100 + rank)
+    x = torch.randn(BATCH, DIM)
+    loss = DenoisingScoreMatching(model=model, noise_scale=NOISE)(x)
+    try:
+        loss.backward()
+        raised = None
+    except RuntimeError as e:
+        raised = str(e)
+    save_result(tmpdir, rank, {"raised": raised})
+
+
+def test_hook_path_double_backward_still_unsupported():
+    results = spawn_dist(_hook_path_worker)
+    for res in results:
+        assert res["raised"] is not None, (
+            "The FSDP2 hook path ran a score-matching double backward. The "
+            "upstream limitation this suite is designed around has been lifted;"
+            " revisit the functional-path requirement."
+        )
+
+
+def _functional_worker(rank, world_size, tmpdir):
+    from torch.distributed.tensor import DTensor, Shard
+    from torch.func import functional_call
+
+    torch.manual_seed(0)
+    net = _make_net()
+    ref = copy.deepcopy(net)
+    mesh = cpu_mesh(world_size)
+    fsdp.fully_shard(net, mesh=mesh)
+    params = dict(net.named_parameters())
+
+    torch.manual_seed(100 + rank)
+    x = torch.randn(BATCH, DIM)
+    noise = torch.randn_like(x) * NOISE
+    x_pert = (x + noise).detach()
+    target = -noise / (NOISE**2)
+
+    x_dt = DTensor.from_local(x_pert, mesh, [Shard(0)], run_check=False)
+    x_dt.requires_grad_(True)
+    energy = functional_call(ref, params, (x_dt,)).squeeze(-1)
+    score = torch.autograd.grad(energy.sum(), x_dt, create_graph=True)[0]
+    target_dt = DTensor.from_local(target, mesh, [Shard(0)], run_check=False)
+    loss = 0.5 * (score - target_dt).square().sum(dim=1).mean()
+    loss.backward()
+    loss_val = loss.detach()
+    if isinstance(loss_val, DTensor):
+        loss_val = loss_val.full_tensor()
+
+    x_ref = x_pert.clone().requires_grad_(True)
+    e_ref = ref(x_ref).squeeze(-1)
+    score_ref = torch.autograd.grad(e_ref.sum(), x_ref, create_graph=True)[0]
+    loss_ref = 0.5 * (score_ref - target).square().sum(dim=1).mean()
+    loss_ref.backward()
+
+    ref_grads = {n: p.grad for n, p in ref.named_parameters()}
+    max_err = 0.0
+    for n, p in params.items():
+        if p.grad is None:
+            # score-independent params (a final-layer bias is a constant
+            # energy offset) legitimately get no grad; the reference agrees
+            assert ref_grads[n] is None, f"missing sharded grad for {n}"
+            continue
+        full = p.grad.full_tensor() if isinstance(p.grad, DTensor) else p.grad
+        mean = ref_grads[n].detach().clone()
+        dist.all_reduce(mean)
+        mean /= world_size
+        max_err = max(max_err, (full - mean).abs().max().item())
+    save_result(tmpdir, rank, {"max_err": max_err, "loss": float(loss_val)})
+
+
+def test_functional_score_path_matches_reference():
+    results = spawn_dist(_functional_worker)
+    losses = {round(r["loss"], 6) for r in results}
+    assert len(losses) == 1, f"global loss differs across ranks: {losses}"
+    for res in results:
+        assert res["max_err"] < 1e-5, res

--- a/torchebm/distributed.py
+++ b/torchebm/distributed.py
@@ -1,0 +1,88 @@
+r"""Guarded `torch.distributed` helpers for distributed-aware components.
+
+TorchEBM components never require an initialized process group: every helper
+here degrades to a no-op or identity in single-process runs, so behavior is
+unchanged when `torch.distributed` is not in use. Components accept an
+optional ``process_group`` only where the math is batch-global (e.g. minibatch
+OT couplings); no default ``forward()``/``sample()`` path issues a collective.
+"""
+
+from typing import Any, Optional
+
+import torch
+import torch.distributed as dist
+
+__all__ = [
+    "is_distributed",
+    "get_rank",
+    "get_world_size",
+    "all_gather_cat",
+    "broadcast_object",
+]
+
+
+def is_distributed() -> bool:
+    r"""Whether `torch.distributed` is available and a process group is initialized."""
+    return dist.is_available() and dist.is_initialized()
+
+
+def get_rank(group: Optional["dist.ProcessGroup"] = None) -> int:
+    r"""Rank of this process in `group`; 0 when not distributed."""
+    return dist.get_rank(group) if is_distributed() else 0
+
+
+def get_world_size(group: Optional["dist.ProcessGroup"] = None) -> int:
+    r"""Number of processes in `group`; 1 when not distributed."""
+    return dist.get_world_size(group) if is_distributed() else 1
+
+
+def all_gather_cat(
+    x: torch.Tensor,
+    group: Optional["dist.ProcessGroup"] = None,
+    dim: int = 0,
+) -> torch.Tensor:
+    r"""Gather `x` from every rank and concatenate along `dim`.
+
+    Identity when not distributed. Requires equal shapes on every rank (the
+    library convention of equal per-rank batches). The result carries no
+    gradient; callers that need differentiable gathers must handle that
+    themselves.
+
+    Args:
+        x: Local tensor to gather.
+        group: Process group; the default group when None.
+        dim: Concatenation dimension.
+
+    Returns:
+        Tensor of shape `x.shape` with `dim` scaled by the world size, ordered
+        by rank; `x` itself when not distributed.
+    """
+    world = get_world_size(group)
+    if world == 1:
+        return x
+    x = x.detach().contiguous()
+    out = [torch.empty_like(x) for _ in range(world)]
+    dist.all_gather(out, x, group=group)
+    return torch.cat(out, dim=dim)
+
+
+def broadcast_object(
+    obj: Any,
+    src: int = 0,
+    group: Optional["dist.ProcessGroup"] = None,
+) -> Any:
+    r"""Broadcast a picklable object from rank `src`; identity when not distributed.
+
+    Args:
+        obj: Object to broadcast (significant on `src` only).
+        src: Source rank.
+        group: Process group; the default group when None.
+
+    Returns:
+        The object from rank `src` on every rank.
+    """
+    if get_world_size(group) == 1:
+        return obj
+    buf = [obj if get_rank(group) == src else None]
+    dist.broadcast_object_list(buf, src=src, group=group)
+    return buf[0]


### PR DESCRIPTION
Guarded torch.distributed helpers (no-op single-process, no collectives on default paths) plus a 2-process gloo test harness with explicit CPU mesh and crash logging. Pins two facts as regression tests: the FSDP2 hook path cannot run the double backward score matching needs, and the functional-call score path on sharded DTensor params matches unsharded reference gradients. resolves #243