### PR TITLE
Distributed foundations: process-group shim and functional score path

### DIFF
--- a/tests/distributed/dist_harness.py
+++ b/tests/distributed/dist_harness.py
@@ -1,16 +1,14 @@
 r"""Spawn harness for the 2-process gloo/CPU distributed suite.
 
-Lessons this harness hard-codes (learned from the design spikes):
+Children hide CUDA, and meshes are created explicitly on cpu via `cpu_mesh`:
+the DeviceMesh device heuristic selects cuda whenever a GPU is visible, and
+multiple gloo CPU processes driving one device crash inside functional
+collectives. Children also run faulthandler into per-rank crash logs so a
+SIGSEGV produces a stack trace instead of a bare ProcessExitedException.
 
-- The DeviceMesh device heuristic silently picks cuda when a GPU is visible,
-  and two gloo CPU processes then drive one GPU and segfault inside functional
-  collectives. Children therefore hide CUDA, and meshes are created explicitly
-  on cpu via `cpu_mesh`.
-- Children run faulthandler into per-rank crash logs so a SIGSEGV still
-  produces a stack instead of a bare ProcessExitedException.
-
-Worker functions must be top-level in their test module (spawn pickles them by
-reference; children inherit sys.path, so pytest-imported test modules resolve).
+Worker functions must be top-level in their test module: spawn pickles them by
+reference, and children inherit sys.path, so pytest-imported test modules
+resolve.
 """
 
 import faulthandler

--- a/tests/distributed/test_fsdp2_score_matching.py
+++ b/tests/distributed/test_fsdp2_score_matching.py
@@ -1,14 +1,16 @@
-r"""Pins the FSDP2 facts the distributed score-matching contract is built on.
+r"""FSDP2 facts that score-matching support relies on.
 
 1. The hook path (`fully_shard` wrappers) cannot run the double backward that
    score matching needs: the post-backward hook reshards parameter storage the
    second-order graph still references, independent of `reshard_after_forward`.
-   If torch ever lifts this, the failure test breaks loudly and the
+   If a torch release lifts this, the failure test here breaks loudly and the
    functional-path requirement can be revisited.
-2. The functional path (`functional_call` on a hook-free skeleton with the
+2. The functional path (`functional_call` on an unwrapped module with the
    sharded DTensor params and a batch-sharded input) runs the double backward
-   through differentiable DTensor collectives and reproduces the gradients of
-   an unsharded reference with global-batch-mean semantics.
+   through differentiable DTensor collectives; `DenoisingScoreMatching` with
+   `use_autograd=False` reproduces the gradients of an unsharded reference
+   with global-batch-mean semantics.
+3. The autograd path fails fast with an actionable error under DTensor params.
 """
 
 import copy
@@ -18,6 +20,8 @@ import pytest
 import torch
 import torch.distributed as dist
 from torch import nn
+
+from torchebm.core import BaseModel
 
 from dist_harness import cpu_mesh, save_result, spawn_dist
 
@@ -35,35 +39,35 @@ BATCH = 8
 NOISE = 0.1
 
 
-def _make_net():
-    return nn.Sequential(
-        nn.Linear(DIM, 16), nn.SiLU(), nn.Linear(16, 16), nn.SiLU(), nn.Linear(16, 1)
-    )
+class MLPEnergy(BaseModel):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(DIM, 16), nn.SiLU(), nn.Linear(16, 16), nn.SiLU(), nn.Linear(16, 1)
+        )
+
+    def forward(self, x):
+        return self.net(x).squeeze(-1)
 
 
-def _hook_path_worker(rank, world_size, tmpdir):
-    from torchebm.core import BaseModel
-    from torchebm.losses import DenoisingScoreMatching
-
-    class MLPEnergy(BaseModel):
-        def __init__(self):
-            super().__init__()
-            self.net = _make_net()
-
-        def forward(self, x):
-            return self.net(x).squeeze(-1)
-
-    torch.manual_seed(0)
-    model = MLPEnergy()
+def _shard(model, world_size):
     mesh = cpu_mesh(world_size)
     for m in model.net:
         if isinstance(m, nn.Linear):
             fsdp.fully_shard(m, mesh=mesh)
     fsdp.fully_shard(model.net, mesh=mesh)
+    return model
+
+
+def _hook_path_worker(rank, world_size, tmpdir):
+    torch.manual_seed(0)
+    model = _shard(MLPEnergy(), world_size)
 
     torch.manual_seed(100 + rank)
-    x = torch.randn(BATCH, DIM)
-    loss = DenoisingScoreMatching(model=model, noise_scale=NOISE)(x)
+    x = torch.randn(BATCH, DIM).requires_grad_(True)
+    energy = model(x)
+    score = torch.autograd.grad(energy.sum(), x, create_graph=True)[0]
+    loss = 0.5 * score.square().sum(dim=1).mean()
     try:
         loss.backward()
         raised = None
@@ -76,65 +80,82 @@ def test_hook_path_double_backward_still_unsupported():
     results = spawn_dist(_hook_path_worker)
     for res in results:
         assert res["raised"] is not None, (
-            "The FSDP2 hook path ran a score-matching double backward. The "
-            "upstream limitation this suite is designed around has been lifted;"
-            " revisit the functional-path requirement."
+            "The FSDP2 hook path ran a score-matching double backward; this "
+            "upstream limitation appears lifted. Revisit the functional-path "
+            "requirement for score matching under fully_shard."
         )
 
 
-def _functional_worker(rank, world_size, tmpdir):
-    from torch.distributed.tensor import DTensor, Shard
-    from torch.func import functional_call
+def _functional_dsm_worker(rank, world_size, tmpdir):
+    from torchebm.losses import DenoisingScoreMatching
 
     torch.manual_seed(0)
-    net = _make_net()
-    ref = copy.deepcopy(net)
-    mesh = cpu_mesh(world_size)
-    fsdp.fully_shard(net, mesh=mesh)
-    params = dict(net.named_parameters())
+    model = MLPEnergy()
+    ref_model = copy.deepcopy(model)
+    model = _shard(model, world_size)
+
+    loss_fn = DenoisingScoreMatching(
+        model=model,
+        noise_scale=NOISE,
+        use_autograd=False,
+        functional_model=MLPEnergy(),
+    )
+    ref_loss_fn = DenoisingScoreMatching(model=ref_model, noise_scale=NOISE)
 
     torch.manual_seed(100 + rank)
     x = torch.randn(BATCH, DIM)
-    noise = torch.randn_like(x) * NOISE
-    x_pert = (x + noise).detach()
-    target = -noise / (NOISE**2)
-
-    x_dt = DTensor.from_local(x_pert, mesh, [Shard(0)], run_check=False)
-    x_dt.requires_grad_(True)
-    energy = functional_call(ref, params, (x_dt,)).squeeze(-1)
-    score = torch.autograd.grad(energy.sum(), x_dt, create_graph=True)[0]
-    target_dt = DTensor.from_local(target, mesh, [Shard(0)], run_check=False)
-    loss = 0.5 * (score - target_dt).square().sum(dim=1).mean()
+    torch.manual_seed(7 + rank)
+    loss = loss_fn(x)
     loss.backward()
-    loss_val = loss.detach()
-    if isinstance(loss_val, DTensor):
-        loss_val = loss_val.full_tensor()
+    torch.manual_seed(7 + rank)
+    ref_loss = ref_loss_fn(x)
+    ref_loss.backward()
 
-    x_ref = x_pert.clone().requires_grad_(True)
-    e_ref = ref(x_ref).squeeze(-1)
-    score_ref = torch.autograd.grad(e_ref.sum(), x_ref, create_graph=True)[0]
-    loss_ref = 0.5 * (score_ref - target).square().sum(dim=1).mean()
-    loss_ref.backward()
-
-    ref_grads = {n: p.grad for n, p in ref.named_parameters()}
+    ref_grads = {n: p.grad for n, p in ref_model.named_parameters()}
     max_err = 0.0
-    for n, p in params.items():
+    for n, p in model.named_parameters():
         if p.grad is None:
-            # score-independent params (a final-layer bias is a constant
-            # energy offset) legitimately get no grad; the reference agrees
             assert ref_grads[n] is None, f"missing sharded grad for {n}"
             continue
-        full = p.grad.full_tensor() if isinstance(p.grad, DTensor) else p.grad
+        full = p.grad.full_tensor() if hasattr(p.grad, "full_tensor") else p.grad
         mean = ref_grads[n].detach().clone()
         dist.all_reduce(mean)
         mean /= world_size
         max_err = max(max_err, (full - mean).abs().max().item())
-    save_result(tmpdir, rank, {"max_err": max_err, "loss": float(loss_val)})
+    save_result(
+        tmpdir,
+        rank,
+        {
+            "max_err": max_err,
+            "loss_matches_local_ref": bool(
+                torch.allclose(loss.detach(), ref_loss.detach(), atol=1e-6)
+            ),
+        },
+    )
 
 
-def test_functional_score_path_matches_reference():
-    results = spawn_dist(_functional_worker)
-    losses = {round(r["loss"], 6) for r in results}
-    assert len(losses) == 1, f"global loss differs across ranks: {losses}"
+def test_functional_dsm_matches_unsharded_reference():
+    results = spawn_dist(_functional_dsm_worker)
     for res in results:
+        assert res["loss_matches_local_ref"], res
         assert res["max_err"] < 1e-5, res
+
+
+def _autograd_fail_fast_worker(rank, world_size, tmpdir):
+    from torchebm.losses import DenoisingScoreMatching
+
+    torch.manual_seed(0)
+    model = _shard(MLPEnergy(), world_size)
+    loss_fn = DenoisingScoreMatching(model=model, noise_scale=NOISE)
+    try:
+        loss_fn(torch.randn(BATCH, DIM))
+        msg = None
+    except RuntimeError as e:
+        msg = str(e)
+    save_result(tmpdir, rank, {"msg": msg})
+
+
+def test_autograd_path_fails_fast_with_dtensor_params():
+    results = spawn_dist(_autograd_fail_fast_worker)
+    for res in results:
+        assert res["msg"] is not None and "use_autograd=False" in res["msg"], res

--- a/tests/losses/test_functional_score_path.py
+++ b/tests/losses/test_functional_score_path.py
@@ -1,0 +1,111 @@
+r"""Single-process parity of the functional score path against autograd."""
+
+import pytest
+import torch
+from torch import nn
+
+from torchebm.core import BaseModel
+from torchebm.losses import (
+    DenoisingScoreMatching,
+    ScoreMatching,
+    SlicedScoreMatching,
+)
+
+
+class MLPEnergy(BaseModel):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(nn.Linear(4, 16), nn.SiLU(), nn.Linear(16, 1))
+
+    def forward(self, x):
+        return self.net(x).squeeze(-1)
+
+
+def _loss_and_grads(loss_fn, model, x, seed):
+    model.zero_grad(set_to_none=True)
+    torch.manual_seed(seed)
+    loss = loss_fn(x)
+    loss.backward()
+    grads = [
+        None if p.grad is None else p.grad.clone() for p in model.parameters()
+    ]
+    return loss.detach(), grads
+
+
+@pytest.mark.parametrize(
+    "cls,kwargs",
+    [
+        (DenoisingScoreMatching, {"noise_scale": 0.1}),
+        (ScoreMatching, {"hessian_method": "approx"}),
+        (SlicedScoreMatching, {"n_projections": 4}),
+    ],
+)
+def test_functional_matches_autograd(cls, kwargs):
+    torch.manual_seed(0)
+    model = MLPEnergy()
+    x = torch.randn(8, 4)
+    loss_a, grads_a = _loss_and_grads(
+        cls(model=model, use_autograd=True, **kwargs), model, x, seed=7
+    )
+    loss_f, grads_f = _loss_and_grads(
+        cls(model=model, use_autograd=False, **kwargs), model, x, seed=7
+    )
+    assert torch.allclose(loss_a, loss_f, atol=1e-6)
+    for ga, gf in zip(grads_a, grads_f):
+        if ga is None:
+            assert gf is None
+        else:
+            assert torch.allclose(ga, gf, atol=1e-6)
+
+
+def test_functional_model_is_structural_only():
+    torch.manual_seed(0)
+    model = MLPEnergy()
+    template = MLPEnergy()
+    x = torch.randn(8, 4)
+    kwargs = {"noise_scale": 0.1, "use_autograd": False}
+    loss_t, grads_t = _loss_and_grads(
+        DenoisingScoreMatching(model=model, functional_model=template, **kwargs),
+        model,
+        x,
+        seed=7,
+    )
+    loss_d, grads_d = _loss_and_grads(
+        DenoisingScoreMatching(model=model, **kwargs), model, x, seed=7
+    )
+    assert torch.allclose(loss_t, loss_d)
+    for gt, gd in zip(grads_t, grads_d):
+        if gt is None:
+            assert gd is None
+        else:
+            assert torch.allclose(gt, gd)
+    assert all(p.grad is None for p in template.parameters())
+
+
+def test_functional_model_not_registered():
+    loss_fn = DenoisingScoreMatching(
+        model=MLPEnergy(), use_autograd=False, functional_model=MLPEnergy()
+    )
+    assert not any(k.startswith("_functional_model") for k in loss_fn.state_dict())
+    assert len(list(loss_fn.parameters())) == len(list(loss_fn.model.parameters()))
+
+
+def test_functional_works_on_parameterless_model():
+    from torchebm.core import DoubleWellModel
+
+    x = torch.randn(8, 2)
+    loss_a, _ = _loss_and_grads(
+        DenoisingScoreMatching(model=DoubleWellModel(), noise_scale=0.1),
+        DoubleWellModel(),
+        x,
+        seed=7,
+    )
+    loss_f, _ = _loss_and_grads(
+        DenoisingScoreMatching(
+            model=DoubleWellModel(), noise_scale=0.1, use_autograd=False
+        ),
+        DoubleWellModel(),
+        x,
+        seed=7,
+    )
+    assert torch.allclose(loss_a, loss_f, atol=1e-6)

--- a/torchebm/core/base_loss.py
+++ b/torchebm/core/base_loss.py
@@ -20,6 +20,14 @@ from torchebm.core.base_module import warn_once
 logger = logging.getLogger(__name__)
 
 
+def _dtensor_type():
+    try:
+        from torch.distributed.tensor import DTensor
+    except ImportError:
+        return None
+    return DTensor
+
+
 class BaseLoss(Schedulable, TorchEBMModule, ABC):
     """
     Abstract base class for loss functions used in energy-based models.
@@ -401,9 +409,22 @@ class BaseScoreMatching(BaseLoss):
         model (BaseModel): The energy-based model to be trained.
         noise_scale (float): The scale of noise for perturbation in denoising variants.
         regularization_strength (float): The coefficient for regularization terms.
-        use_autograd (bool): Whether to use `torch.autograd` for computing derivatives.
+        use_autograd (bool): If True, compute the score by differentiating
+            `model` in place. If False, use the functional path:
+            `torch.func.functional_call` on a hook-free module with the model's
+            current parameters. The functional path is required when the model's
+            parameters are sharded DTensors (e.g. FSDP2 `fully_shard`), whose
+            forward/backward hooks cannot run the second-order backward score
+            matching needs.
         hutchinson_samples (int): The number of random samples for Hutchinson's trick.
         custom_regularization (Optional[Callable]): An optional function for custom regularization.
+        functional_model (Optional[nn.Module]): Hook-free module used by the
+            functional path in place of `model` for `functional_call`. Required
+            when `model` holds FSDP-managed submodules (their hooks fire even
+            under `functional_call`); pass an unwrapped instance of the same
+            architecture. Ignored by the autograd path. Held as a structural
+            template only: not registered as a submodule, its own parameters are
+            never used.
     """
 
     def __init__(
@@ -414,6 +435,7 @@ class BaseScoreMatching(BaseLoss):
         use_autograd: bool = True,
         hutchinson_samples: int = 1,
         custom_regularization: Optional[Callable] = None,
+        functional_model: Optional[nn.Module] = None,
         *args,
         **kwargs,
     ):
@@ -424,6 +446,145 @@ class BaseScoreMatching(BaseLoss):
         self.use_autograd = use_autograd
         self.hutchinson_samples = hutchinson_samples
         self.custom_regularization = custom_regularization
+        object.__setattr__(self, "_functional_model", functional_model)
+
+    @property
+    def functional_model(self) -> Optional[nn.Module]:
+        r"""Template module for the functional score path (never trained)."""
+        return self._functional_model
+
+    def _functional_state(self) -> Tuple[dict, dict, Optional[object]]:
+        r"""Collect the model's parameters/buffers and their mesh, if sharded.
+
+        Returns:
+            `(params, buffers, mesh)` where `mesh` is the 1-D device mesh of
+            the DTensor parameters, or None for plain tensors.
+        """
+        params = dict(self.model.named_parameters())
+        buffers = dict(self.model.named_buffers())
+        dtensor = _dtensor_type()
+        mesh = None
+        if dtensor is not None:
+            for p in params.values():
+                if isinstance(p, dtensor):
+                    mesh = p.device_mesh
+                    break
+        if mesh is not None and mesh.ndim != 1:
+            raise NotImplementedError(
+                f"The functional score path supports 1-D device meshes only, "
+                f"got a {mesh.ndim}-D mesh."
+            )
+        return params, buffers, mesh
+
+    def _functional_leaf(self, x: torch.Tensor, mesh) -> torch.Tensor:
+        r"""Detached grad-leaf for the functional path, batch-sharded on `mesh`."""
+        if mesh is None:
+            return x.detach().requires_grad_(True)
+        from torch.distributed.tensor import DTensor, Shard
+
+        leaf = DTensor.from_local(x.detach(), mesh, [Shard(0)], run_check=False)
+        leaf.requires_grad_(True)
+        return leaf
+
+    def _functional_energy(
+        self,
+        leaf: torch.Tensor,
+        params: dict,
+        buffers: dict,
+        mesh,
+        model_kwargs: Optional[dict] = None,
+    ) -> torch.Tensor:
+        r"""Energy via `functional_call` on the hook-free template module.
+
+        On a mesh, plain buffers are wrapped as Replicate DTensors and tensor
+        `model_kwargs` are wrapped Shard(0) when batch-aligned, Replicate
+        otherwise, so no operator mixes DTensor and plain operands.
+        """
+        module = self._functional_model
+        kwargs = dict(model_kwargs or {})
+        if mesh is None:
+            module = module if module is not None else self.model
+        else:
+            if module is None:
+                raise RuntimeError(
+                    "functional_model is required when the model's parameters "
+                    "are sharded DTensors: FSDP hooks fire even under "
+                    "functional_call. Pass an unwrapped instance of the model "
+                    "architecture at construction."
+                )
+            from torch.distributed.tensor import DTensor, Replicate, Shard
+
+            local_batch = leaf.to_local().shape[0]
+            buffers = {
+                n: (
+                    b
+                    if isinstance(b, DTensor)
+                    else DTensor.from_local(b, mesh, [Replicate()], run_check=False)
+                )
+                for n, b in buffers.items()
+            }
+            for k, v in kwargs.items():
+                if torch.is_tensor(v) and not isinstance(v, DTensor):
+                    placement = (
+                        Shard(0)
+                        if v.ndim > 0 and v.shape[0] == local_batch
+                        else Replicate()
+                    )
+                    kwargs[k] = DTensor.from_local(
+                        v, mesh, [placement], run_check=False
+                    )
+        return torch.func.functional_call(
+            module, {**params, **buffers}, (leaf,), kwargs=kwargs
+        )
+
+    def _functional_localize(self, t: torch.Tensor, mesh) -> torch.Tensor:
+        r"""Convert a Shard(0) result to its local shard with averaged gradients.
+
+        `to_local` alone would leave parameter gradients as the cross-rank sum
+        (the backward of the parameter all-gather is a summing reduce-scatter);
+        the identity-forward rescale below divides them by the world size, so a
+        local-mean loss yields global-batch-mean gradients, matching the
+        convention of gradient-averaging data parallelism.
+        """
+        if mesh is None:
+            return t
+        from torch.distributed.tensor import Shard
+
+        if t.placements != (Shard(0),):
+            t = t.redistribute(mesh, [Shard(0)])
+        local = t.to_local()
+        c = 1.0 / mesh.size()
+        return local * c + local.detach() * (1.0 - c)
+
+    def _functional_score(
+        self, x_perturbed: torch.Tensor, model_kwargs: Optional[dict] = None
+    ) -> torch.Tensor:
+        r"""Score \(\nabla_x E(x)\) via the functional path.
+
+        The input is treated as a constant: the returned score is
+        differentiable with respect to the model parameters (`create_graph`),
+        not with respect to the caller's tensor.
+        """
+        params, buffers, mesh = self._functional_state()
+        leaf = self._functional_leaf(x_perturbed, mesh)
+        with self.autocast_context():
+            energy = self._functional_energy(leaf, params, buffers, mesh, model_kwargs)
+        score = torch.autograd.grad(energy.sum(), leaf, create_graph=True)[0]
+        return self._functional_localize(score, mesh)
+
+    def _require_autograd_safe_params(self) -> None:
+        r"""Reject the in-place autograd path when parameters are sharded."""
+        dtensor = _dtensor_type()
+        if dtensor is not None and isinstance(
+            next(self.model.parameters(), None), dtensor
+        ):
+            raise RuntimeError(
+                "The autograd score path cannot run with FSDP-managed "
+                "(DTensor) parameters: resharding hooks free storage the "
+                "second-order backward still references. Construct the loss "
+                "with use_autograd=False and functional_model=<unwrapped "
+                "instance of the model architecture>."
+            )
 
     @property
     def noise_scale(self) -> float:
@@ -470,18 +631,17 @@ class BaseScoreMatching(BaseLoss):
         else:
             x_perturbed = x
 
+        if not self.use_autograd:
+            return self._functional_score(x_perturbed, model_kwargs=model_kwargs)
+
+        self._require_autograd_safe_params()
         if not x_perturbed.requires_grad:
             x_perturbed.requires_grad_(True)
 
         with self.autocast_context():
             energy = self.model(x_perturbed, **(model_kwargs or {}))
 
-        if self.use_autograd:
-            score = torch.autograd.grad(energy.sum(), x_perturbed, create_graph=True)[0]
-        else:
-            raise NotImplementedError(
-                "Custom gradient computation must be implemented in subclasses"
-            )
+        score = torch.autograd.grad(energy.sum(), x_perturbed, create_graph=True)[0]
 
         return score
 

--- a/torchebm/losses/score_matching.py
+++ b/torchebm/losses/score_matching.py
@@ -5,6 +5,7 @@ import warnings
 from typing import Optional, Union, Dict, Tuple, Any, Callable
 
 import torch
+from torch import nn
 from torch.func import grad as func_grad, vmap, jacrev
 
 
@@ -47,6 +48,8 @@ class ScoreMatching(BaseScoreMatching):
         hessian_method: str = "exact",
         regularization_strength: float = 0.0,
         custom_regularization: Optional[Callable] = None,
+        use_autograd: bool = True,
+        functional_model: Optional[nn.Module] = None,
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
         *args,
@@ -55,8 +58,9 @@ class ScoreMatching(BaseScoreMatching):
         super().__init__(
             model=model,
             regularization_strength=regularization_strength,
-            use_autograd=True,
+            use_autograd=use_autograd,
             custom_regularization=custom_regularization,
+            functional_model=functional_model,
             dtype=dtype,
             device=device,
             *args,
@@ -160,6 +164,12 @@ class ScoreMatching(BaseScoreMatching):
                 "hessian_method='approx' or DenoisingScoreMatching for "
                 "conditional training."
             )
+        if self._functional_state()[2] is not None:
+            raise NotImplementedError(
+                "Exact score matching computes per-sample Hessians with vmap, "
+                "which does not support DTensor parameters. Use "
+                "hessian_method='approx' or DenoisingScoreMatching."
+            )
         batch_size = x.shape[0]
         x_flat = x.view(batch_size, -1).detach().requires_grad_(True)
 
@@ -252,6 +262,8 @@ class DenoisingScoreMatching(BaseScoreMatching):
         noise_scale: float = 0.01,
         regularization_strength: float = 0.0,
         custom_regularization: Optional[Callable] = None,
+        use_autograd: bool = True,
+        functional_model: Optional[nn.Module] = None,
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
         *args,
@@ -261,8 +273,9 @@ class DenoisingScoreMatching(BaseScoreMatching):
             model=model,
             noise_scale=noise_scale,
             regularization_strength=regularization_strength,
-            use_autograd=True,
+            use_autograd=use_autograd,
             custom_regularization=custom_regularization,
+            functional_model=functional_model,
             dtype=dtype,
             device=device,
             *args,
@@ -377,6 +390,8 @@ class SlicedScoreMatching(BaseScoreMatching):
         projection_type: str = "rademacher",
         regularization_strength: float = 0.0,
         custom_regularization: Optional[Callable] = None,
+        use_autograd: bool = True,
+        functional_model: Optional[nn.Module] = None,
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
         *args,
@@ -385,8 +400,9 @@ class SlicedScoreMatching(BaseScoreMatching):
         super().__init__(
             model=model,
             regularization_strength=regularization_strength,
-            use_autograd=True,
+            use_autograd=use_autograd,
             custom_regularization=custom_regularization,
+            functional_model=functional_model,
             dtype=dtype,
             device=device,
             *args,
@@ -493,11 +509,14 @@ class SlicedScoreMatching(BaseScoreMatching):
             .expand(self.n_projections, *x.shape)
             .contiguous()
             .view(-1, *x.shape[1:])
-        ).requires_grad_(
-            True
         )  # final shape: (n_particles * batch_size, d). tracing the shape: (batch_size, d) -> (1, batch_size, d)
         # -> (n_particles, batch_size, d) -> (n_particles, batch_size, d) -> (n_particles * batch_size, d)
 
+        if not self.use_autograd:
+            return self._functional_sliced_loss(dup_x)
+
+        self._require_autograd_safe_params()
+        dup_x = dup_x.requires_grad_(True)
         n_vectors = self._get_random_projections(dup_x)
 
         logp = (-self.model(dup_x)).sum()
@@ -514,5 +533,40 @@ class SlicedScoreMatching(BaseScoreMatching):
         loss = term2 + term1
 
         return loss.mean()
+
+    def _functional_sliced_loss(self, dup_x: torch.Tensor) -> torch.Tensor:
+        r"""Sliced loss via the functional path (see `BaseScoreMatching`).
+
+        Projections are drawn locally and, on a mesh, wrapped batch-sharded so
+        both second-order gradients run through differentiable DTensor
+        collectives instead of module hooks.
+
+        Args:
+            dup_x (torch.Tensor): Projection-tiled batch of shape
+                `(n_projections * batch_size, d)`.
+
+        Returns:
+            torch.Tensor: The scalar sliced score matching loss.
+        """
+        params, buffers, mesh = self._functional_state()
+        n_vectors = self._get_random_projections(dup_x)
+        leaf = self._functional_leaf(dup_x, mesh)
+        if mesh is not None:
+            from torch.distributed.tensor import DTensor, Shard
+
+            n_vectors = DTensor.from_local(
+                n_vectors, mesh, [Shard(0)], run_check=False
+            )
+        energy = self._functional_energy(leaf, params, buffers, mesh)
+        grad1 = torch.autograd.grad((-energy).sum(), leaf, create_graph=True)[0]
+        v_score = torch.sum(grad1 * n_vectors, dim=-1)
+        grad_v = torch.autograd.grad(v_score.sum(), leaf, create_graph=True)[0]
+        term2 = torch.sum(n_vectors * grad_v, dim=-1)
+
+        v_score = self._functional_localize(v_score, mesh)
+        term2 = self._functional_localize(term2, mesh)
+        term1 = (0.5 * v_score.square()).view(self.n_projections, -1).mean(dim=0)
+        term2 = term2.view(self.n_projections, -1).mean(dim=0)
+        return (term1 + term2).mean()
 
     


### PR DESCRIPTION
Adds guarded torch.distributed helpers (identity single-process, no collectives on default paths) with a 2-process gloo test harness, and a functional score-computation path so score-matching losses train under FSDP2 fully_shard: functional_call on an unwrapped template with the model's sharded DTensor parameters, batch-sharded input, and world-averaged gradient semantics. The in-place autograd path fails fast with an actionable error under DTensor parameters, since resharding hooks cannot run the required second-order backward. Parity is pinned single-process (functional == autograd) and distributed (sharded gradients match an unsharded reference). resolves #243 resolves #244