### PR TITLE
  feat(losses): flow matching endpoint and loss api hygiene 

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -79,33 +79,65 @@ jobs:
         git tag $new_tag
         git push origin $new_tag
 
-  # update-changelog:
-  #   needs: update-tag
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     changes: ${{ steps.changelog.outputs.changes }}
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
+  # CHANGELOG.md automation: every master push (PR merge) refreshes the
+  # [Unreleased] section from all commits since the last GitHub Release; a
+  # '#release' push instead promotes that range to a version section. Ranges
+  # are bounded by real releases, never by the per-push tags minted above.
+  # The bot commits carry [skip ci], so they trigger neither tags nor CI.
+  changelog:
+    if: ${{ !contains(github.event.head_commit.message, '#release') }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-  #     - name: Update CHANGELOG.md
-  #       id: changelog
-  #       uses: requarks/changelog-action@v1
-  #       with:
-  #         token: ${{ github.token }}
-  #         tag: ${{ needs.update-tag.outputs.new_tag }}
-  #         excludeTypes: ""
-  #         includeInvalidCommits: true
-  #         useGitmojis: false
+    - name: Render unreleased changes
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        pip install --quiet git-cliff
+        last=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
+        git-cliff --config cliff.toml --strip all "${last}..HEAD" -o body.md
+        python scripts/update_changelog.py unreleased --body body.md
+        rm body.md
 
-  #     - name: Commit CHANGELOG.md
-  #       uses: stefanzweifel/git-auto-commit-action@v5
-  #       with:
-  #         branch: master
-  #         commit_message: "chore: update CHANGELOG.md for ${{ needs.update-tag.outputs.new_tag }} [skip ci]"
-  #         file_pattern: CHANGELOG.md
+    - name: Commit CHANGELOG.md
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        branch: master
+        commit_message: "chore(changelog): refresh unreleased [skip ci]"
+        file_pattern: CHANGELOG.md
+
+  changelog-release:
+    needs: [update-tag]
+    if: contains(github.event.head_commit.message, '#release')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Promote unreleased to ${{ needs.update-tag.outputs.new_tag }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        NEW_TAG: ${{ needs.update-tag.outputs.new_tag }}
+      run: |
+        pip install --quiet git-cliff
+        last=$(gh release list --json tagName --jq '.[].tagName' | grep -vx "$NEW_TAG" | head -1)
+        git-cliff --config cliff.toml --strip all "${last}..HEAD" -o body.md
+        python scripts/update_changelog.py release --version "$NEW_TAG" \
+          --date "$(date -u +%F)" --body body.md
+        rm body.md
+
+    - name: Commit CHANGELOG.md
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        branch: master
+        commit_message: "chore(changelog): release ${{ needs.update-tag.outputs.new_tag }} [skip ci]"
+        file_pattern: CHANGELOG.md
 
   release:
     needs: [update-tag]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,52 +9,109 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- All samplers accept an `integrator` constructor argument: `None` (current default), a registry name (`"heun"`, `"rk4"`, `"dopri5"`, ...), or an integrator instance. Compatibility is enforced at construction (Langevin: SDE family; HMC: separable symplectic; RMHMC: non-separable symplectic; Flow: Runge-Kutta family). Passed instances must match the sampler's device/dtype (no implicit `.to()`); integrator hyperparameters (`atol`/`rtol`/solver iterations) are set on the instance, not via sampler kwargs
-- `BaseSymplecticIntegrator` (core): shared base for the leapfrog family with a `separable` contract flag; `LeapfrogIntegrator` and `GeneralisedLeapfrogIntegrator` now inherit from it
-- `get_integrator(name, device, dtype)` string registry in `torchebm.integrators`
-- `torchebm.interpolants.interpolant_utils`: `get_interpolant` moved here from `torchebm.losses.loss_utils` (still re-exported there) plus a new `resolve_interpolant(interpolant, default, owner)` helper mirroring `resolve_integrator`
-- `resolve_integrator` exported from `torchebm.integrators`
-- Cross-sampler API contract test (`tests/samplers/test_api_contract.py`) pinning the shared `sample()` signature, return types, trajectory/thin shapes, and constructor ordering for every sampler
-- Tiered, runnable examples curriculum under `examples/` (foundations, sampling, training, showcase), smoke-tested in CI: `pytest -m examples tests/examples` executes every example on CPU with `TORCHEBM_SMOKE=1` shrinking iteration counts, so an API change that breaks an example fails the build
-- Documentation: a Concepts section (design and scope, the energy-based view, sampling and integration, learning objectives, interpolants and couplings) replacing the tutorials; component cards, class diagrams, the package tree, and the base-class contract table are now generated from the installed package at build time (`docs/hooks/gen_diagrams.py`), so they cannot drift from the code
+- [`e9a0aaa`](https://github.com/soran-ghaderi/torchebm/commit/e9a0aaab45584d4986d23e3205d5993b75e0e37d) - add guarded process-group helpers + gloo spawn harness and fsdp2 score-matching pins
+- [`767ba76`](https://github.com/soran-ghaderi/torchebm/commit/767ba76f695c7326249a75e1237060378d601ae6) - add guarded process-group helpers + gloo spawn harness and shim tests #243
+- [`06f0993`](https://github.com/soran-ghaderi/torchebm/commit/06f099305c21ad95aee348a9992cec71e0daabbb) - functional score path for sharded dtensor models + tests for functional score parity and fsdp2 double-backward pins(#244)
+- [`f1ba1de`](https://github.com/soran-ghaderi/torchebm/commit/f1ba1de2929bcf8ef79f223c8c50840a32d0ed6a) - thread generator through sampler, integrator, loss, coupling,  rng + generator contract and per-rank decorrelation tests
+- [`0036630`](https://github.com/soran-ghaderi/torchebm/commit/003663034ec523d3824fd34687b63819559cc5eb) - unsharded context manager for k-step mcmc under fsdp2 + energy model parity tests #246
+- [`bbef1b8`](https://github.com/soran-ghaderi/torchebm/commit/bbef1b83efa7630f1190fffa980132298be9e470) - opt-in cross-rank pcd replay buffer mixing + rank-local semantics and checkpoint contract
+- [`0211394`](https://github.com/soran-ghaderi/torchebm/commit/02113943cee5dae92066b8d8aa21c14ab81f42fa) - process-group-aware global-batch sinkhorn coupling with rank0-broadcast draws
+- [`fdfe71b`](https://github.com/soran-ghaderi/torchebm/commit/fdfe71baaaa928099243c7980b0bf916a488dc52) - fail-fast second-order guards under sharded params + fsdp2 loss parity matrix (#248)
 
 ### Changed
 
-- **BREAKING** `FlowSampler` is configured entirely at construction: `mode="ode"|"sde"` selects the process, and `reverse`, `diffusion_form`, `diffusion_norm`, `last_step`, `last_step_size` are constructor arguments (SDE-only options raise `ValueError` in ODE mode). `sample()` now follows the standard `BaseSampler` contract, including `thin`, `return_trajectory`, and `return_diagnostics` (keys `"mean"`, `"var"`, `"t"`) with fixed-step integrators; adaptive integrators return the final state only. `n_steps=None` resolves to 50 (ODE) / 250 (SDE). Fixed-step sampling now advances schedulers once per step
-- **BREAKING** `sample(x=None)` requires `dim=` (or model-based inference in the HMC family); the silent `dim=10` default is gone. `dim` accepts an int or a shape tuple, replacing `FlowSampler`'s `shape=` kwarg
-- Sampler constructors and `sample()` signatures no longer accept unused `*args, **kwargs`
-- `resolve_integrator` validates the integrator family for registry names too, not only instances (e.g. `FlowSampler(mode="sde", integrator="rk4")` now raises `TypeError` at construction)
-- `RiemannianManifoldHMC` resolves its default integrator through `resolve_integrator` like every other sampler
-- `FlowSampler` adaptive ODE sampling (`dopri5`, `dopri8`, `bosh3`, `adaptive_heun`) now runs on native integrators; torchdiffeq is no longer used or required (removed from the `eqm` extra). Outputs are statistically equivalent but not bitwise identical to torchdiffeq (different step-size controller); the default `dopri5` path is ~3x faster on the sampler benchmark
-- `FlowSampler` reverse-time sampling works with adaptive integrators (decreasing time grids are reparameterized internally)
-- Packaging: the source distribution no longer ships `docs/`, `examples/`, `benchmarks/`, or `tests/` (new `MANIFEST.in`; `setuptools_scm` had been adding every git-tracked file), cutting the sdist from tens of megabytes to ~150 KB. README image and link URLs are absolute so they render on PyPI
+- [`aac6092`](https://github.com/soran-ghaderi/torchebm/commit/aac6092fa57594cd378ba1d8cbc0899a65aacde3) - point tests and docs at the relocated utils shim
 
-### Removed
+### Fixed
 
-- **BREAKING** `FlowSampler.sample_ode` / `FlowSampler.sample_sde` and the per-call `method`/`atol`/`rtol`/`ode_method`/`sde_method`/`mode`/`shape` sampling kwargs (deprecated in 0.6.4). Passing a removed kwarg raises `TypeError` with a migration hint. Migration:
+- [`56e6522`](https://github.com/soran-ghaderi/torchebm/commit/56e65226f7c2a631c7dd9c154e30f5fbefed0aa6) - numpy-free tensor broadcasts + optimizer-ready grads on the functional score path (#249)
+- [`c12a58f`](https://github.com/soran-ghaderi/torchebm/commit/c12a58fbf9efb70c85aae7f623f049f9dbaa0fd3) - numpy-free tensor broadcasts + optimizer-ready grads on the functional score path, shim moved to utils (#249)
 
-  | old | new |
-  |---|---|
-  | `s.sample_ode(z, num_steps=50)` | `FlowSampler(model, ...).sample(x=z, n_steps=50)` |
-  | `s.sample_sde(z, num_steps=250, diffusion_form=..., last_step=...)` | `FlowSampler(model, mode="sde", diffusion_form=..., last_step=...).sample(x=z, n_steps=250)` |
-  | `s.sample(mode="sde", ...)` | constructor `mode="sde"` |
-  | `s.sample(shape=(n, C, H, W))` | `s.sample(n_samples=n, dim=(C, H, W))` |
-  | `sample_ode(..., method="rk4", atol=..., rtol=...)` | constructor `integrator="rk4"` or an instance with `atol`/`rtol` set |
-  | `sample_ode(..., reverse=True)` | constructor `reverse=True` |
+### Performance
 
-### Deprecated
+- [`4eb623f`](https://github.com/soran-ghaderi/torchebm/commit/4eb623f69729348d680f245b41cc2895ad5fbd5b) - lazy-load external badges and drop dead analytics snippet
+- [`5c66fba`](https://github.com/soran-ghaderi/torchebm/commit/5c66fba001f83289aff8d5f1200d51e9d718f5d3) - lazy-load external badges and drop dead analytics, load mathjax and mermaid on demand
 
-- `RiemannianManifoldHMC` `solver_max_iter`/`solver_tol`/`solver_check_every`: construct `GeneralisedLeapfrogIntegrator(solver_max_iter=...)` and pass it as `integrator=`
+### Other
 
-- `EnergyMatchingLoss`: Energy Matching (arXiv:2504.10612) — OT flow-matching warm-up plus contrastive-divergence sharpening on a single time-independent scalar potential, with split Langevin negatives, one-sided trimmed mean, and stability clamp
-- `torchebm.couplings` package for source/target pairing, with a contract closed against future coupling families: results are structured `CouplingResult` objects that unpack as the `(x0, x1)` pair while carrying extras as attributes (per-pair `weights` for unbalanced OT); `couple(x0, x1=None, **kwargs)` takes an optional target (generate families) and a conditioning channel. Hierarchy in core: `BaseCoupling` root, `BaseCostCoupling` (cost + solver template), `BaseModelCoupling` (generate from a model map). Concretes — all torch-native, no scipy/POT: `IndependentCoupling`, `ExactOTCoupling` (Bertsekas auction), `SinkhornCoupling` (log-domain entropic), `GreedyCoupling` (nearest-free-pair approximate OT), `UnbalancedSinkhornCoupling` (KL-relaxed marginals, per-pair importance weights), `ReflowCoupling` (rectified-flow pairs `x1 = Phi(x0)` via a FlowSampler or any callable, covering closed-form transport maps). Name registry: `get_coupling`/`resolve_coupling` with `"independent"`, `"ot"`/`"exact_ot"`, `"sinkhorn"`, `"greedy"`, `"unbalanced_sinkhorn"`; model couplings are instance-only
-- `EnergyMatchingLoss` flow term consumes coupling `weights` when present (importance-weighted mean; uniform weights reduce exactly to the plain mean)
-- `TemperatureScheduler`: piecewise-linear temperature profile eps(t) for two-regime sampling; returns sqrt(eps) for direct use as `LangevinDynamics` `noise_scale`
-- `InteractionModel`: pairwise repulsive interaction wrapper with `Schedulable` strength for diverse sampling
-- `LangevinDynamics` optional per-step state `clamp=(min, max)` for image-space EBM stabilization
-- Loss utils: `get_coupling`, `trimmed_mean`, `compute_flow_weight`
-- `EnergyMatchingLoss` arbitrary-source transport: pass `x0=...` to `forward`/`training_losses` (the paper's 8-Gaussians-to-two-moons setup); source-initialized negatives follow
-- Examples: `examples/20-training/04-energy-matching/01-energy-matching-2d` (two moons, minimal) and `02-energy-matching-paper-2d` (paper suite: 8G-to-moons transport, trajectories, sample evolution, LID estimation, repulsive diverse sampling; live terminal progress)
+- [`a25471b`](https://github.com/soran-ghaderi/torchebm/commit/a25471b934eaccedfcea13098a39483828d5ac89) - functional score parity and fsdp2 double-backward pins
+- [`f583901`](https://github.com/soran-ghaderi/torchebm/commit/f583901d2fbebb4eae9ea8a0c5ae26a3acc7691b) - require python 3.10 and torch 2.10 for generator support
+- [`80e1bce`](https://github.com/soran-ghaderi/torchebm/commit/80e1bce94affbb57174eb07405b02f884e779bd0) - pin sync-free hot paths and document the gpu-first contract #239
+- [`264a73f`](https://github.com/soran-ghaderi/torchebm/commit/264a73fc990b824290dbb8ab7d93c5d46b426c25) - standard software title, unified bibtex, orcid and preferred-citation
+- [`86a5c6c`](https://github.com/soran-ghaderi/torchebm/commit/86a5c6c603132980459c62a630cd52655fa43acd) - pin ema updates on identically sharded params and the dcp + rank-local checkpoint recipe
+- [`3499d43`](https://github.com/soran-ghaderi/torchebm/commit/3499d435d4a0082f997d70c9f61d8ec17a0af143) - device-generic nccl harness and 4-gpu fsdp2 training-step benchmark (#249)
+
+## [0.7.5] - 2026-07-16
+
+### Added
+
+- [`7d7cfb2`](https://github.com/soran-ghaderi/torchebm/commit/7d7cfb235049a4f0a709ad0cd3d8d6da9d2fe3a7) - add explicit midpoint RK2
+- [`fa1263d`](https://github.com/soran-ghaderi/torchebm/commit/fa1263dcfded4a7748ccceed79d0f5b095eccee4) - thread model_kwargs conditioning through all samplers,  losses, base modules, and couplings
+- [`96f1268`](https://github.com/soran-ghaderi/torchebm/commit/96f126869ac6da4381350e1af1066e6f5191df70) - eqmenergy adapter for gradient sampling of equilibrium-matching fields
+- [`51a4ded`](https://github.com/soran-ghaderi/torchebm/commit/51a4ded2b6c7e49f088e7f04c2e952bd564f6f1f) - x0 and coupling support in equilibriummatchingloss
+
+### Changed
+
+- [`c800f26`](https://github.com/soran-ghaderi/torchebm/commit/c800f268d5fcc199b0badbc105c78d0a5e9b9866) - generate synthetic datasets with torch instead of numpy
+
+### Fixed
+
+- [`60284c5`](https://github.com/soran-ghaderi/torchebm/commit/60284c52c2631630414d21def5cecc7c701dc93d) - self-host paper figures, semanticscholar serves non-image content-type that github/pypi camo rejects
+- [`b395194`](https://github.com/soran-ghaderi/torchebm/commit/b395194383d2f90c0c0aad706d9ba40b5a94aaac) - register EnergyMatchingLoss model_type so its bench builds
+
+### Performance
+
+- [`0496a12`](https://github.com/soran-ghaderi/torchebm/commit/0496a12c0e93b40e92d3da850fe370e636036aa7) - instant navigation, deferred pinned mathjax, cdn preconnect
+- [`393865d`](https://github.com/soran-ghaderi/torchebm/commit/393865d937ac3b5e6f6ec4dd93c25644cf48b99a) - compute basemodel.gradient in the input dtype with fp32 opt-in + device-tensor metrics, sync once per epoch
+- [`6231624`](https://github.com/soran-ghaderi/torchebm/commit/623162453117907660c88209937a199ac56c1a9e) - drop per-step scalar-tensor syncs; single greedy transfer
+
+### Other
+
+- [`e85e5a7`](https://github.com/soran-ghaderi/torchebm/commit/e85e5a7ae79f7e1809783c3e91db48b4422ef61e) - expand midpoint coverage
+- [`879b35d`](https://github.com/soran-ghaderi/torchebm/commit/879b35dbe5a10358840a59ba944202b3ffa0da6c) - add contributing guide
+- [`11f42fc`](https://github.com/soran-ghaderi/torchebm/commit/11f42fcab7c046ae8e73a9f9e504dd73a015b32d) - cover model_kwargs contract, conditional negatives, deprecations over all components and couplings!
+- [`e3e2c03`](https://github.com/soran-ghaderi/torchebm/commit/e3e2c0362c924bf524a09bee6a32dbffee7b4654) - cover eqmenergy, x0/coupling, and sampling-route agreement
+- [`c6be616`](https://github.com/soran-ghaderi/torchebm/commit/c6be6165b2384a96471f8aa94e5f8f37e3a3d798) - coherent eqm sampling routes and diverse coda
+- [`8044140`](https://github.com/soran-ghaderi/torchebm/commit/80441402f2e712d0f935c7d692f4d3f9f2e34811) - lead with simulation-free, gpu-first narrative across pypi, docs, and readme
+- [`e5ce988`](https://github.com/soran-ghaderi/torchebm/commit/e5ce988dfb81edf8444f7cb7ae67824bad074261) - drop verbose inline comments from library code
+
+## [0.7.1] - 2026-07-13
+
+### Added
+
+- [`e8fd25d`](https://github.com/soran-ghaderi/torchebm/commit/e8fd25df9627dd516962c2bead4fa1a32f9c65f3) - auto-generate example pages from examples/ via in-memory mkdocs hooks
+- [`55a2705`](https://github.com/soran-ghaderi/torchebm/commit/55a2705270c825eff185f96fad1ee7f08e6060f3) - add basesymplecticintegrator base for leapfrog family
+- [`dc0c5c3`](https://github.com/soran-ghaderi/torchebm/commit/dc0c5c3a6c5636158772eaf896d2ae7e839c775e) - add get_integrator string registry and resolver
+- [`90cfb00`](https://github.com/soran-ghaderi/torchebm/commit/90cfb00f2f9952ec47c2212a9936c0a7bbc94a00) - accept integrator instances and registry names in langevin/hmc/rmhmc
+- [`ad7b274`](https://github.com/soran-ghaderi/torchebm/commit/ad7b2748f8bebbe0f69c1b27c08a248301ad008f) - add temperaturescheduler and basecoupling primitives
+- [`3c2c8cc`](https://github.com/soran-ghaderi/torchebm/commit/3c2c8cc69829ee898bad3cab2580318ca479a2b9) - constructor integrator for flowsampler, deprecate per-call method args, drop torchdiffeq
+- [`b3931cc`](https://github.com/soran-ghaderi/torchebm/commit/b3931cc27f33966e6fa0327eb2c74d67207fc3cc) - structured couplingresult return and generalized root contract
+- [`97ad838`](https://github.com/soran-ghaderi/torchebm/commit/97ad8381db0bf532bbf9d2ef261cc4d4e1798f0a) - greedy, unbalanced sinkhorn, and model-induced reflow couplings
+- [`a92542f`](https://github.com/soran-ghaderi/torchebm/commit/a92542f2ea9e1246a765885ef83958bf21bc9102) - wire energymatchingloss exports and flow helpers
+- [`698c02c`](https://github.com/soran-ghaderi/torchebm/commit/698c02c463d77a5c628f2426bdf858c2024544ae) - interaction model for energy matching repulsion
+- [`6138091`](https://github.com/soran-ghaderi/torchebm/commit/6138091307e1e3c4084ffe7cd1d21fbf51663605) - flowsampler mode-based constructor and conforming sample contract (#171)
+- [`146a737`](https://github.com/soran-ghaderi/torchebm/commit/146a73760958ca38b74c368cba783b2fdc1de7df) - tiered ci-tested curriculum with generated pages
+- [`0142c5d`](https://github.com/soran-ghaderi/torchebm/commit/0142c5d43fbed1d1d80bf49876d33e938bb69183) - concepts section, generated component views, and new navigation. slim the sdist, add pyyaml to dev, guard package discovery
+
+### Changed
+
+- [`aaef0ed`](https://github.com/soran-ghaderi/torchebm/commit/aaef0ed2dce81b8a35fa61fac29ad9cc1894ce54) - move get_interpolant to interpolants and add resolve_interpolant
+- [`3e753fe`](https://github.com/soran-ghaderi/torchebm/commit/3e753fe510ec366a2f811a9ff380c8a7359e01c8) - int-or-tuple dim with shared state init and drop kwargs cascades (#172)
+- [`c8b1d6c`](https://github.com/soran-ghaderi/torchebm/commit/c8b1d6cc6c6ad915d784b0d0835241ee7c006daa) - export resolve_integrator and validate family for registry names (#174)
+
+### Fixed
+
+- [`df8b33d`](https://github.com/soran-ghaderi/torchebm/commit/df8b33d42f86a4079a93de040d2eb0390d7d8d93) - add repo root to pytest pythonpath so tests.conftest imports survive package discovery guard
+
+### Other
+
+- [`81feb5b`](https://github.com/soran-ghaderi/torchebm/commit/81feb5bce12275ad3fd1d42b0822f064187d6ca7) - remove polyfill to avoid its popup on the website
+- [`cc5dc19`](https://github.com/soran-ghaderi/torchebm/commit/cc5dc198c7ab2e66e4b47c7cfc7dce270852d537) - cover symplectic base, registry, integrator injection
+- [`0cba390`](https://github.com/soran-ghaderi/torchebm/commit/0cba3907a3e1e8934dd08c06faf97b1c737e9a38) - euler/dopri5 variants via ctor integrator, changelog
+- [`3237d7f`](https://github.com/soran-ghaderi/torchebm/commit/3237d7f4385fb11ed720afafdf5d179f424619a1) - update issue templates and changelog
+- [`75c4d47`](https://github.com/soran-ghaderi/torchebm/commit/75c4d47027acfca487a0609e9a280df0e809db0a) - cross-sampler api contract guard (#175)
+- [`9de9916`](https://github.com/soran-ghaderi/torchebm/commit/9de9916ff5d390fc0016be453e18ca7c9040ebf8) - update changelog for flowsampler standardization (#170)
+- [`84ae09a`](https://github.com/soran-ghaderi/torchebm/commit/84ae09a3264374eb8a63a4323352581723455d11) - readme rewrite and 0.7.1 release notes
 
 ## [0.6.0] - 2026-05-31
 
@@ -466,7 +523,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [`6007e01`](https://github.com/soran-ghaderi/torchebm/commit/6007e017ecc02c2d508cb4492fb80c74fecfd097) - example test for ci/cd
 - [`12f1490`](https://github.com/soran-ghaderi/torchebm/commit/12f149092e5d034390b551cdcf388fb3a885498d) - add tests
 
-[Unreleased]: https://github.com/soran-ghaderi/torchebm/compare/v0.5.10...HEAD
+[Unreleased]: https://github.com/soran-ghaderi/torchebm/compare/v0.7.5...HEAD
+[0.7.5]: https://github.com/soran-ghaderi/torchebm/compare/v0.7.1...v0.7.5
+[0.7.1]: https://github.com/soran-ghaderi/torchebm/compare/v0.6.0...v0.7.1
+[0.6.0]: https://github.com/soran-ghaderi/torchebm/compare/v0.5.8...v0.6.0
 [0.5.8]: https://github.com/soran-ghaderi/torchebm/compare/v0.5.7...v0.5.8
 [0.5.7]: https://github.com/soran-ghaderi/torchebm/compare/v0.5.6...v0.5.7
 [0.5.6]: https://github.com/soran-ghaderi/torchebm/compare/v0.5.4...v0.5.6

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ If TorchEBM is useful in your research, please cite it:
 }
 ```
 
-## Citations
+## References
 
 ```bibtex
 @article{hinton2002training,

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,41 @@
+# git-cliff configuration for the CHANGELOG.md sections.
+#
+# Output matches the format of the previously generated sections: Keep a
+# Changelog labels (Added/Changed/Deprecated/Removed/Fixed/Performance/Other)
+# and short-SHA commit links on every bullet; non-conventional commits land
+# under Other.
+#
+# CI always passes an explicit release-to-release commit range and owns the
+# version headings (scripts/update_changelog.py splices the rendered body into
+# CHANGELOG.md), so tags are ignored as section boundaries here: the repo
+# mints a tag on every master push and only GitHub Releases mark real
+# versions.
+
+[changelog]
+trim = true
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}\
+### {{ group | striptags | trim }}
+
+{% for commit in commits %}\
+- [`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/soran-ghaderi/torchebm/commit/{{ commit.id }}) - {% if commit.breaking %}**BREAKING** {% endif %}{{ commit.message }}
+{% endfor %}
+{% endfor %}\
+"""
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+protect_breaking_commits = true
+ignore_tags = ".*"
+commit_parsers = [
+  { message = "^feat", group = "<!-- 0 -->Added" },
+  { message = "^refactor", group = "<!-- 1 -->Changed" },
+  { message = "^deprecate", group = "<!-- 2 -->Deprecated" },
+  { message = "^(remove|revert)", group = "<!-- 3 -->Removed" },
+  { message = "^fix", group = "<!-- 4 -->Fixed" },
+  { message = "^perf", group = "<!-- 5 -->Performance" },
+  { message = "^Merge ", skip = true },
+  { message = "^chore\\(changelog\\)", skip = true },
+  { message = ".*", group = "<!-- 6 -->Other" },
+]

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -88,14 +88,9 @@ records the gap explicitly.
 
 ## How do I cite TorchEBM?
 
-```bibtex
-@misc{ghaderi2024torchebm,
-  author       = {Ghaderi, Soran},
-  title        = {{TorchEBM}: A Composable {PyTorch} Library for Energy-Based and Transport-Based Generative Models},
-  year         = {2024},
-  howpublished = {\url{https://github.com/soran-ghaderi/torchebm}},
-}
-```
+Use the BibTeX entry on the [home page](../index.md#citation). GitHub also
+serves it from `CITATION.cff` through the "Cite this repository" button, which
+exports BibTeX and APA.
 
 ## How do I contribute?
 

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -1,0 +1,56 @@
+r"""Splice a rendered changes body into CHANGELOG.md.
+
+Only the ``## [Unreleased]`` block is ever touched; released sections below
+it are frozen. Bodies come from git-cliff (see cliff.toml); CI drives this on
+master pushes.
+
+Usage:
+    python scripts/update_changelog.py unreleased --body FILE
+        Replace the [Unreleased] body.
+
+    python scripts/update_changelog.py release --version vX.Y.Z \
+        --date YYYY-MM-DD --body FILE
+        Replace the [Unreleased] block with a version section and open a
+        fresh empty [Unreleased] above it.
+"""
+
+import argparse
+import pathlib
+import re
+import sys
+
+CHANGELOG = pathlib.Path(__file__).resolve().parent.parent / "CHANGELOG.md"
+HEADING = "## [Unreleased]"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("unreleased", "release"))
+    parser.add_argument("--body", required=True, help="file with the rendered body")
+    parser.add_argument("--version", help="release mode: version (v prefix ok)")
+    parser.add_argument("--date", help="release mode: YYYY-MM-DD")
+    args = parser.parse_args()
+    if args.mode == "release" and not (args.version and args.date):
+        parser.error("release mode requires --version and --date")
+
+    body = pathlib.Path(args.body).read_text().strip()
+    text = CHANGELOG.read_text()
+    if HEADING not in text:
+        sys.exit(f"CHANGELOG.md has no '{HEADING}' section")
+    head, rest = text.split(HEADING, 1)
+    match = re.search(r"\n## \[", rest)
+    frozen = rest[match.start() :] if match else "\n"
+
+    if args.mode == "unreleased":
+        new = f"{head}{HEADING}\n\n{body}\n{frozen}"
+    else:
+        version = args.version.lstrip("v")
+        new = (
+            f"{head}{HEADING}\n\n"
+            f"## [{version}] - {args.date}\n\n{body}\n{frozen}"
+        )
+    CHANGELOG.write_text(new)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integrators/test_euler_maruyama.py
+++ b/tests/integrators/test_euler_maruyama.py
@@ -296,6 +296,54 @@ def test_integrate_sde(integrator):
     assert torch.all(torch.isfinite(result["x"]))
 
 
+def test_integrate_sde_with_noise_scale(integrator):
+    """Integration accepts a scalar noise_scale instead of a diffusion callable."""
+    device = integrator.device
+    state = {"x": torch.randn(4, 2, device=device)}
+
+    result = integrator.integrate(
+        state,
+        step_size=0.1,
+        n_steps=5,
+        drift=lambda x_, t_: -x_,
+        noise_scale=1.0,
+    )
+
+    assert result["x"].shape == (4, 2)
+    assert torch.all(torch.isfinite(result["x"]))
+
+
+def test_integrate_noise_scale_diffusion_equivalence(integrator):
+    """Over a full trajectory, noise_scale sigma matches diffusion = sigma**2."""
+    device = integrator.device
+    noise_scale = 1.5
+    x = torch.randn(8, 2, device=device)
+    drift = lambda x_, t_: -x_
+
+    gen = torch.Generator(device=device)
+    gen.manual_seed(0)
+    from_scale = integrator.integrate(
+        {"x": x.clone()},
+        step_size=0.01,
+        n_steps=10,
+        drift=drift,
+        noise_scale=noise_scale,
+        generator=gen,
+    )
+
+    gen.manual_seed(0)
+    from_diffusion = integrator.integrate(
+        {"x": x.clone()},
+        step_size=0.01,
+        n_steps=10,
+        drift=drift,
+        diffusion=lambda x_, t_: torch.full_like(x_, noise_scale**2),
+        generator=gen,
+    )
+
+    assert torch.allclose(from_scale["x"], from_diffusion["x"], atol=1e-6)
+
+
 def test_integrate_with_model(integrator, gaussian_model):
     """Test integration using model gradient."""
     device = integrator.device

--- a/tests/losses/test_constructor_kwargs.py
+++ b/tests/losses/test_constructor_kwargs.py
@@ -1,0 +1,94 @@
+"""Unknown constructor kwargs must fail with an actionable TypeError.
+
+Without validation, a bogus keyword falls through BaseLoss -> Schedulable ->
+TorchEBMModule into ``nn.Module.__init__`` and dies with a bare "unexpected
+keyword argument" that names neither the loss's supported parameters nor the
+installed version.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from torchebm import __version__
+from torchebm.core import BaseModel
+from torchebm.losses import (
+    ContrastiveDivergence,
+    DenoisingScoreMatching,
+    EnergyMatchingLoss,
+    EquilibriumMatchingLoss,
+    ScoreMatching,
+    SlicedScoreMatching,
+)
+from torchebm.samplers import LangevinDynamics
+
+
+class QuadraticModel(BaseModel):
+    def forward(self, x):
+        return 0.5 * x.flatten(1).square().sum(dim=1)
+
+
+class VelocityModel(nn.Module):
+    def forward(self, x, t=None, **kwargs):
+        return x
+
+
+def _make_cd(**kwargs):
+    model = QuadraticModel()
+    return ContrastiveDivergence(
+        model=model, sampler=LangevinDynamics(model=model), **kwargs
+    )
+
+
+LOSS_FACTORIES = [
+    pytest.param(ContrastiveDivergence, _make_cd, id="ContrastiveDivergence"),
+    pytest.param(
+        ScoreMatching,
+        lambda **kw: ScoreMatching(model=QuadraticModel(), **kw),
+        id="ScoreMatching",
+    ),
+    pytest.param(
+        DenoisingScoreMatching,
+        lambda **kw: DenoisingScoreMatching(model=QuadraticModel(), **kw),
+        id="DenoisingScoreMatching",
+    ),
+    pytest.param(
+        SlicedScoreMatching,
+        lambda **kw: SlicedScoreMatching(model=QuadraticModel(), **kw),
+        id="SlicedScoreMatching",
+    ),
+    pytest.param(
+        EquilibriumMatchingLoss,
+        lambda **kw: EquilibriumMatchingLoss(model=VelocityModel(), **kw),
+        id="EquilibriumMatchingLoss",
+    ),
+    pytest.param(
+        EnergyMatchingLoss,
+        lambda **kw: EnergyMatchingLoss(model=QuadraticModel(), **kw),
+        id="EnergyMatchingLoss",
+    ),
+]
+
+
+@pytest.mark.parametrize("cls,factory", LOSS_FACTORIES)
+def test_bogus_kwarg_raises_actionable_typeerror(cls, factory):
+    with pytest.raises(TypeError) as excinfo:
+        factory(bogus_kwarg=123)
+    msg = str(excinfo.value)
+    assert cls.__name__ in msg
+    assert "bogus_kwarg" in msg
+    assert "Supported parameters" in msg
+    assert "model" in msg
+    assert "device" in msg
+    assert __version__ in msg
+
+
+def test_intermediate_base_params_still_cascade():
+    loss = ScoreMatching(model=QuadraticModel(), hutchinson_samples=4)
+    assert loss.hutchinson_samples == 4
+
+
+def test_supported_parameters_cover_full_chain():
+    with pytest.raises(TypeError) as excinfo:
+        ScoreMatching(model=QuadraticModel(), bogus_kwarg=123)
+    assert "hutchinson_samples" in str(excinfo.value)

--- a/tests/losses/test_equilibrium_matching.py
+++ b/tests/losses/test_equilibrium_matching.py
@@ -149,8 +149,8 @@ def test_eqm_gradient_direction():
 
 
 def test_eqm_time_invariance():
-    """Verify model receives zeroed time when time_invariant=True.
-    
+    """Verify the model always receives zeroed time.
+
     EqM learns a time-invariant energy landscape by zeroing out time.
     """
     class TimeTrackingModel(nn.Module):
@@ -163,40 +163,15 @@ def test_eqm_time_invariance():
             return torch.zeros_like(x)
     
     model = TimeTrackingModel()
-    loss_fn = EquilibriumMatchingLoss(model=model, time_invariant=True)
-    
+    loss_fn = EquilibriumMatchingLoss(model=model)
+
     x = torch.randn(4, 4)
     loss_fn(x)
-    
+
     # Time should be all zeros for time-invariance
     assert model.received_time is not None, "Model should receive time argument"
     assert torch.all(model.received_time == 0), \
         f"EqM should zero out time (got {model.received_time})"
-
-
-def test_eqm_time_variant_mode():
-    """Verify model receives actual time when time_invariant=False."""
-    class TimeTrackingModel(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.received_time = None
-            
-        def forward(self, x, t=None, **kwargs):
-            self.received_time = t
-            return torch.zeros_like(x)
-    
-    model = TimeTrackingModel()
-    loss_fn = EquilibriumMatchingLoss(
-        model=model, time_invariant=False, check_time_conditioning=False
-    )
-
-    x = torch.randn(4, 4)
-    loss_fn(x)
-
-    # Time should NOT be all zeros
-    assert model.received_time is not None
-    assert not torch.all(model.received_time == 0), \
-        "With time_invariant=False, model should receive actual time values"
 
 
 def test_eqm_gradient_flow():
@@ -669,68 +644,126 @@ def test_repr_records_ct_and_multiplier():
     assert "ct_multiplier=2.0" in repr_str
 
 
-class TimeConsumingModel(nn.Module):
-    def __init__(self, dim=4):
-        super().__init__()
-        self.linear = nn.Linear(dim, dim)
-        self.calls = 0
-
-    def forward(self, x, t=None, **kwargs):
-        self.calls += 1
-        return self.linear(x) + t.view(-1, *([1] * (x.ndim - 1))) * 2.0
+def test_t_sampler_unknown_raises():
+    with pytest.raises(ValueError, match="lognormal"):
+        EquilibriumMatchingLoss(model=DummyModel(), t_sampler="bogus")
 
 
-def test_time_probe_raises_for_t_ignoring_model():
+def test_t_p_std_nonpositive_raises():
+    with pytest.raises(ValueError, match="t_p_std"):
+        EquilibriumMatchingLoss(
+            model=DummyModel(), t_sampler="lognormal", t_p_std=0.0
+        )
+
+
+def test_t_sampler_lognormal_matches_edm_formula():
+    z = torch.tensor([0.0, 1.0, -1.0, 0.5])
     loss_fn = EquilibriumMatchingLoss(
-        model=DummyModel(out_val=0.5), time_invariant=False
+        model=DummyModel(), t_sampler="lognormal", train_eps=0.0, device="cpu"
     )
-    with pytest.raises(ValueError, match="DummyModel"):
-        loss_fn(torch.randn(4, 4))
+    with unittest.mock.patch(
+        "torchebm.losses.equilibrium_matching.torch.randn", return_value=z
+    ):
+        t = loss_fn._sample_t(4, generator=None)
+
+    sigma = torch.exp(z * 1.2 - 1.2)
+    expected = (1.0 / (1.0 + sigma)).clamp(min=1e-4, max=1.0)
+    assert torch.allclose(t, expected, atol=1e-6)
 
 
-def test_time_probe_passes_for_t_consuming_model():
+def test_t_sampler_lognormal_clamps_to_unit_interval():
+    z = torch.tensor([-20.0, 20.0])
     loss_fn = EquilibriumMatchingLoss(
-        model=TimeConsumingModel(), time_invariant=False
+        model=DummyModel(), t_sampler="lognormal", train_eps=0.0, device="cpu"
     )
-    loss = loss_fn(torch.randn(4, 4))
-    assert torch.isfinite(loss)
+    with unittest.mock.patch(
+        "torchebm.losses.equilibrium_matching.torch.randn", return_value=z
+    ):
+        t = loss_fn._sample_t(2, generator=None)
+
+    assert torch.allclose(t, torch.tensor([1.0, 1e-4]))
 
 
-def test_time_probe_runs_once_and_restores_training_mode():
-    model = TimeConsumingModel()
-    model.train()
-    loss_fn = EquilibriumMatchingLoss(model=model, time_invariant=False)
-
-    loss_fn(torch.randn(4, 4))
-    assert model.training
-    assert model.calls == 3  # probe pair + training forward
-
-    loss_fn(torch.randn(4, 4))
-    assert model.calls == 4  # no re-probe
+def test_t_sampler_lognormal_deterministic_with_generator():
+    loss_fn = EquilibriumMatchingLoss(
+        model=DummyModel(), t_sampler="lognormal", device="cpu"
+    )
+    t_first = loss_fn._sample_t(8, torch.Generator().manual_seed(11))
+    t_second = loss_fn._sample_t(8, torch.Generator().manual_seed(11))
+    assert torch.equal(t_first, t_second)
+    assert not torch.all(t_first == t_first[0])
 
 
-def test_time_probe_skipped_when_time_invariant():
-    model = DummyModel(out_val=0.5)
-    loss_fn = EquilibriumMatchingLoss(model=model, time_invariant=True)
-    assert torch.isfinite(loss_fn(torch.randn(4, 4)))
-
-
-def test_time_probe_slices_batch_aligned_model_kwargs():
-    class ConditionalModel(nn.Module):
-        def __init__(self, dim=4):
-            super().__init__()
-            self.linear = nn.Linear(dim, dim)
-
-        def forward(self, x, t=None, y=None, **kwargs):
-            assert y.shape[0] == x.shape[0]
-            return self.linear(x) + t.view(-1, 1) + y.view(-1, 1).float()
+def test_t_sampler_callable_contract():
+    def sampler(batch, *, device, dtype, generator):
+        assert dtype == torch.float32
+        return torch.full((batch,), 0.3, device=device, dtype=dtype)
 
     loss_fn = EquilibriumMatchingLoss(
-        model=ConditionalModel(), time_invariant=False
+        model=DummyModel(), t_sampler=sampler, device="cpu"
     )
-    y = torch.randint(0, 3, (8,))
-    loss = loss_fn(torch.randn(8, 4), model_kwargs={"y": y})
-    assert torch.isfinite(loss)
+    t = loss_fn._sample_t(4, generator=None)
+    assert torch.allclose(t, torch.full((4,), 0.3))
+
+
+def test_t_sampler_lognormal_flows_into_loss():
+    """The drawn lognormal t reaches the loss, exposed via loss_weight_fn."""
+    dim, batch_size = 4, 2
+    x1 = torch.randn(batch_size, dim)
+    x0 = torch.randn(batch_size, dim)
+    z = torch.tensor([0.3, -0.7])
+
+    with unittest.mock.patch(
+        "torchebm.losses.equilibrium_matching.torch.randn", return_value=z
+    ):
+        loss_fn = EquilibriumMatchingLoss(
+            model=DummyModel(out_val=0.5),
+            t_sampler="lognormal",
+            ct="constant",
+            ct_multiplier=1.0,
+            loss_weight_fn=lambda t: t,
+            train_eps=0.0,
+            device="cpu",
+        )
+        loss_val = loss_fn(x1, x0=x0)
+
+    t = (1.0 / (1.0 + torch.exp(z * 1.2 - 1.2))).clamp(min=1e-4, max=1.0)
+    _, ut = get_interpolant("linear").interpolate(x0, x1, t)
+    per_sample = (torch.full_like(ut, 0.5) + ut).square().mean(dim=1)
+    expected = (per_sample * t).mean()
+    assert torch.allclose(loss_val, expected, atol=1e-5)
+
+
+def test_loss_weight_fn_scales_per_sample_loss():
+    dim, batch_size = 4, 2
+    x1 = torch.randn(batch_size, dim)
+    fixed_x0 = torch.randn(batch_size, dim)
+    fixed_t_raw = torch.rand(batch_size)
+
+    with unittest.mock.patch(
+        "torchebm.losses.equilibrium_matching.torch.rand",
+        return_value=fixed_t_raw,
+    ):
+        loss_fn = EquilibriumMatchingLoss(
+            model=DummyModel(out_val=0.5),
+            ct="constant",
+            ct_multiplier=1.0,
+            loss_weight_fn=lambda t: t + 1.0,
+            train_eps=0.0,
+            device="cpu",
+        )
+        loss_val = loss_fn(x1, x0=fixed_x0)
+
+    t = fixed_t_raw
+    _, ut = get_interpolant("linear").interpolate(fixed_x0, x1, t)
+    per_sample = (torch.full_like(ut, 0.5) - (-ut)).square().mean(dim=1)
+    expected = (per_sample * (t + 1.0)).mean()
+    assert torch.allclose(loss_val, expected, atol=1e-5)
+
+
+def test_loss_weight_fn_non_callable_raises():
+    with pytest.raises(TypeError, match="callable or None"):
+        EquilibriumMatchingLoss(model=DummyModel(), loss_weight_fn=5)
 
 
 # Fixture for device testing

--- a/tests/losses/test_equilibrium_matching.py
+++ b/tests/losses/test_equilibrium_matching.py
@@ -570,6 +570,103 @@ def test_weighted_coupling_weights_the_loss():
     assert not torch.allclose(lw, lp)
 
 
+def test_ct_unknown_variant_raises():
+    with pytest.raises(ValueError, match="truncated"):
+        EquilibriumMatchingLoss(model=DummyModel(), ct="bogus")
+
+
+@pytest.mark.parametrize("threshold", [0.0, 1.0])
+def test_ct_truncated_endpoint_threshold_raises_at_construction(threshold):
+    """Threshold endpoints are separate variants, not division-by-zero crashes."""
+    with pytest.raises(ValueError, match="constant"):
+        EquilibriumMatchingLoss(model=DummyModel(), ct_threshold=threshold)
+
+
+@pytest.mark.parametrize(
+    "ct,weight_fn",
+    [
+        ("linear", lambda t: 1.0 - t),
+        ("constant", lambda t: torch.ones_like(t)),
+        (lambda t: t.square(), lambda t: t.square()),
+    ],
+    ids=["linear", "constant", "callable"],
+)
+def test_ct_variants_apply_multiplier(ct, weight_fn):
+    """Every ct variant produces target -ut * c(t) * ct_multiplier."""
+    dim, batch_size = 4, 2
+    multiplier = 3.0
+    x1 = torch.randn(batch_size, dim)
+    fixed_x0 = torch.randn(batch_size, dim)
+    fixed_t_raw = torch.rand(batch_size)
+
+    with unittest.mock.patch(
+        "torchebm.losses.equilibrium_matching.torch.rand",
+        return_value=fixed_t_raw,
+    ):
+        loss_fn = EquilibriumMatchingLoss(
+            model=DummyModel(out_val=0.5),
+            ct=ct,
+            ct_multiplier=multiplier,
+            train_eps=0.0,
+            device="cpu",
+        )
+        loss_val = loss_fn(x1, x0=fixed_x0)
+
+    t = fixed_t_raw
+    _, ut = get_interpolant("linear").interpolate(fixed_x0, x1, t)
+    target = -ut * (weight_fn(t) * multiplier).view(batch_size, 1)
+    expected = (torch.full_like(target, 0.5) - target).square().mean(dim=1).mean()
+    assert torch.allclose(loss_val, expected, atol=1e-5)
+
+
+def test_ct_constant_matches_flow_matching_reference():
+    """ct='constant', ct_multiplier=1 is exactly the negated FM objective.
+
+    Reference FM on Gaussian data: v = -f, loss = ||v - ut||^2. Values and
+    parameter gradients must coincide.
+    """
+    torch.manual_seed(7)
+    dim, batch_size = 4, 16
+    model = LearnableModel(dim=dim)
+    x1 = torch.randn(batch_size, dim)
+    x0 = torch.randn(batch_size, dim)
+    fixed_t_raw = torch.rand(batch_size)
+
+    with unittest.mock.patch(
+        "torchebm.losses.equilibrium_matching.torch.rand",
+        return_value=fixed_t_raw,
+    ):
+        loss_fn = EquilibriumMatchingLoss(
+            model=model,
+            ct="constant",
+            ct_multiplier=1.0,
+            train_eps=0.0,
+            device="cpu",
+        )
+        eqm_loss = loss_fn(x1, x0=x0)
+    eqm_loss.backward()
+    eqm_grads = [p.grad.clone() for p in model.parameters()]
+    model.zero_grad()
+
+    xt, ut = get_interpolant("linear").interpolate(x0, x1, fixed_t_raw)
+    v_pred = -model(xt, torch.zeros_like(fixed_t_raw))
+    fm_loss = (v_pred - ut).square().mean(dim=1).mean()
+
+    assert torch.allclose(eqm_loss, fm_loss, atol=1e-6)
+    fm_loss.backward()
+    for g_eqm, p in zip(eqm_grads, model.parameters()):
+        assert torch.allclose(g_eqm, p.grad, atol=1e-6)
+
+
+def test_repr_records_ct_and_multiplier():
+    loss_fn = EquilibriumMatchingLoss(
+        model=DummyModel(), ct="constant", ct_multiplier=2.0
+    )
+    repr_str = repr(loss_fn)
+    assert "ct='constant'" in repr_str
+    assert "ct_multiplier=2.0" in repr_str
+
+
 # Fixture for device testing
 @pytest.fixture(params=["cpu", "cuda"])
 def device(request):

--- a/tests/losses/test_equilibrium_matching.py
+++ b/tests/losses/test_equilibrium_matching.py
@@ -186,11 +186,13 @@ def test_eqm_time_variant_mode():
             return torch.zeros_like(x)
     
     model = TimeTrackingModel()
-    loss_fn = EquilibriumMatchingLoss(model=model, time_invariant=False)
-    
+    loss_fn = EquilibriumMatchingLoss(
+        model=model, time_invariant=False, check_time_conditioning=False
+    )
+
     x = torch.randn(4, 4)
     loss_fn(x)
-    
+
     # Time should NOT be all zeros
     assert model.received_time is not None
     assert not torch.all(model.received_time == 0), \
@@ -665,6 +667,70 @@ def test_repr_records_ct_and_multiplier():
     repr_str = repr(loss_fn)
     assert "ct='constant'" in repr_str
     assert "ct_multiplier=2.0" in repr_str
+
+
+class TimeConsumingModel(nn.Module):
+    def __init__(self, dim=4):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim)
+        self.calls = 0
+
+    def forward(self, x, t=None, **kwargs):
+        self.calls += 1
+        return self.linear(x) + t.view(-1, *([1] * (x.ndim - 1))) * 2.0
+
+
+def test_time_probe_raises_for_t_ignoring_model():
+    loss_fn = EquilibriumMatchingLoss(
+        model=DummyModel(out_val=0.5), time_invariant=False
+    )
+    with pytest.raises(ValueError, match="DummyModel"):
+        loss_fn(torch.randn(4, 4))
+
+
+def test_time_probe_passes_for_t_consuming_model():
+    loss_fn = EquilibriumMatchingLoss(
+        model=TimeConsumingModel(), time_invariant=False
+    )
+    loss = loss_fn(torch.randn(4, 4))
+    assert torch.isfinite(loss)
+
+
+def test_time_probe_runs_once_and_restores_training_mode():
+    model = TimeConsumingModel()
+    model.train()
+    loss_fn = EquilibriumMatchingLoss(model=model, time_invariant=False)
+
+    loss_fn(torch.randn(4, 4))
+    assert model.training
+    assert model.calls == 3  # probe pair + training forward
+
+    loss_fn(torch.randn(4, 4))
+    assert model.calls == 4  # no re-probe
+
+
+def test_time_probe_skipped_when_time_invariant():
+    model = DummyModel(out_val=0.5)
+    loss_fn = EquilibriumMatchingLoss(model=model, time_invariant=True)
+    assert torch.isfinite(loss_fn(torch.randn(4, 4)))
+
+
+def test_time_probe_slices_batch_aligned_model_kwargs():
+    class ConditionalModel(nn.Module):
+        def __init__(self, dim=4):
+            super().__init__()
+            self.linear = nn.Linear(dim, dim)
+
+        def forward(self, x, t=None, y=None, **kwargs):
+            assert y.shape[0] == x.shape[0]
+            return self.linear(x) + t.view(-1, 1) + y.view(-1, 1).float()
+
+    loss_fn = EquilibriumMatchingLoss(
+        model=ConditionalModel(), time_invariant=False
+    )
+    y = torch.randint(0, 3, (8,))
+    loss = loss_fn(torch.randn(8, 4), model_kwargs={"y": y})
+    assert torch.isfinite(loss)
 
 
 # Fixture for device testing

--- a/tests/losses/test_loss_utils.py
+++ b/tests/losses/test_loss_utils.py
@@ -40,6 +40,12 @@ def test_get_interpolant():
         get_interpolant("unknown")
 
 
+@pytest.mark.parametrize("threshold", [0.0, 1.0])
+def test_compute_eqm_ct_endpoint_threshold_raises(threshold):
+    with pytest.raises(ValueError, match="threshold"):
+        compute_eqm_ct(torch.rand(4), threshold=threshold)
+
+
 def test_compute_eqm_ct():
     # Test formula: c(t) = 4 * min(1, (1-t)/0.2)
     

--- a/tests/samplers/test_flow.py
+++ b/tests/samplers/test_flow.py
@@ -23,6 +23,16 @@ class MockModel(nn.Module):
         return torch.zeros_like(x)
 
 
+class TimeRecordingModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.times = []
+
+    def forward(self, x, t, **kwargs):
+        self.times.append(torch.as_tensor(t).detach().clone())
+        return torch.zeros_like(x)
+
+
 @pytest.fixture
 def device():
     return torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -58,6 +68,51 @@ class TestFlowSampler:
         sampler = FlowSampler(MockModel(), mode="sde", device=device, dtype=dtype)
         assert sampler.diffusion_form == "SBDM"
         assert sampler.diffusion_norm == 1.0
+
+    def test_negate_velocity_conditions_model_on_zero_time(self, device, dtype):
+        """EqM fields are time-invariant: trained on zeroed time, so sampling
+        must condition the model on zeros too, not the integration clock."""
+        model = TimeRecordingModel()
+        sampler = FlowSampler(
+            model,
+            negate_velocity=True,
+            integrator="euler",
+            device=device,
+            dtype=dtype,
+        )
+        sampler.sample(n_samples=2, dim=2, n_steps=4)
+        assert model.times
+        assert all(torch.all(t == 0) for t in model.times)
+
+    def test_plain_velocity_receives_integration_time(self, device, dtype):
+        model = TimeRecordingModel()
+        sampler = FlowSampler(
+            model, integrator="euler", device=device, dtype=dtype
+        )
+        sampler.sample(n_samples=2, dim=2, n_steps=4)
+        assert any(torch.any(t != 0) for t in model.times)
+
+    def test_negate_velocity_sde_score_uses_negated_zero_time_velocity(
+        self, device, dtype
+    ):
+        """SDE mode: the score must come from the sampling velocity v = -f,
+        with the model conditioned on zeroed time."""
+        model = MockModel(mode="constant", val=2.0)
+        sampler = FlowSampler(
+            model,
+            mode="sde",
+            negate_velocity=True,
+            integrator="euler_maruyama",
+            device=device,
+            dtype=dtype,
+        )
+        x = torch.randn(3, 2, device=device, dtype=dtype)
+        t = torch.full((3,), 0.5, device=device, dtype=dtype)
+        score = sampler._get_score()(x, t)
+        expected = sampler.interpolant.velocity_to_score(
+            -torch.full_like(x, 2.0), x, t
+        )
+        assert_close(score, expected)
         assert sampler.last_step == "Mean"
         assert sampler.last_step_size == 0.04
 

--- a/tests/test_citation.py
+++ b/tests/test_citation.py
@@ -1,0 +1,86 @@
+r"""Consistency checks for the project citation.
+
+``CITATION.cff`` is the single source of truth: GitHub renders it, and Zenodo
+reads it to populate the archived record.  The BibTeX block is duplicated in
+``README.md`` (GitHub and PyPI read the README raw, so it can never be
+generated) and on the documentation landing page.  These tests pin the two
+rendered copies to the metadata file so the duplication cannot drift.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+BIBTEX_KEY = "ghaderi2024torchebm"
+
+CITATION_SURFACES = ("README.md", "docs/index.md")
+
+_MISC_BLOCK = re.compile(r"```bibtex\n(@misc\{.*?\n\})\n```", re.S)
+_FIELD = re.compile(r"^\s*(\w+)\s*=\s*\{(.*)\},?$", re.M)
+
+
+def _read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def _bibtex_block(relative_path: str) -> str:
+    blocks = _MISC_BLOCK.findall(_read(relative_path))
+    assert len(blocks) == 1, f"{relative_path}: expected exactly one @misc block"
+    return blocks[0]
+
+
+def _bibtex_fields(block: str) -> dict:
+    return {name: value for name, value in _FIELD.findall(block)}
+
+
+@pytest.fixture(scope="module")
+def cff() -> dict:
+    return yaml.safe_load(_read("CITATION.cff"))
+
+
+@pytest.fixture(scope="module")
+def preferred(cff) -> dict:
+    return cff["preferred-citation"]
+
+
+def test_rendered_citations_are_identical():
+    blocks = {path: _bibtex_block(path) for path in CITATION_SURFACES}
+    assert len(set(blocks.values())) == 1, f"citation blocks differ: {list(blocks)}"
+
+
+def test_citation_is_not_duplicated_further():
+    for path in ROOT.joinpath("docs").rglob("*.md"):
+        if path.relative_to(ROOT).as_posix() in CITATION_SURFACES:
+            continue
+        assert BIBTEX_KEY not in path.read_text(encoding="utf-8"), (
+            f"{path.relative_to(ROOT)} carries its own copy of the citation; "
+            f"link to the canonical one in {CITATION_SURFACES[1]} instead"
+        )
+
+
+@pytest.mark.parametrize("path", CITATION_SURFACES)
+def test_bibtex_matches_citation_cff(path, cff, preferred):
+    fields = _bibtex_fields(_bibtex_block(path))
+
+    assert _bibtex_block(path).startswith(f"@misc{{{BIBTEX_KEY},")
+
+    author = preferred["authors"][0]
+    assert fields["author"] == f"{author['family-names']}, {author['given-names']}"
+
+    assert fields["title"].replace("{", "").replace("}", "") == preferred["title"]
+    assert preferred["title"] == cff["title"]
+
+    assert fields["year"] == str(preferred["year"])
+
+    url = re.fullmatch(r"\\url\{(.*)\}", fields["howpublished"])
+    assert url is not None, "howpublished must wrap the url in \\url{...}"
+    assert url.group(1) == preferred["url"]
+
+
+def test_bibtex_key_encodes_author_and_year(preferred):
+    author = preferred["authors"][0]["family-names"].lower()
+    assert BIBTEX_KEY == f"{author}{preferred['year']}torchebm"

--- a/torchebm/core/base_integrator.py
+++ b/torchebm/core/base_integrator.py
@@ -654,8 +654,6 @@ class BaseSDERungeKuttaIntegrator(BaseRungeKuttaIntegrator):
     def _resolve_diffusion(
         diffusion: Optional[torch.Tensor],
         noise_scale: Optional[torch.Tensor],
-        device: torch.device,
-        dtype: torch.dtype,
     ) -> Optional[torch.Tensor]:
         r"""Return the diffusion coefficient from an explicit value or ``noise_scale``.
 
@@ -712,9 +710,7 @@ class BaseSDERungeKuttaIntegrator(BaseRungeKuttaIntegrator):
             t = torch.zeros(x.size(0), device=x.device, dtype=x.dtype)
 
         drift_fn = self._resolve_drift(drift)
-        diffusion_val = self._resolve_diffusion(
-            diffusion, noise_scale, x.device, x.dtype
-        )
+        diffusion_val = self._resolve_diffusion(diffusion, noise_scale)
 
         x_new = self._deterministic_step(x, step_size, drift_fn, t)
 
@@ -801,9 +797,11 @@ class BaseSDERungeKuttaIntegrator(BaseRungeKuttaIntegrator):
         x = state["x"]
         drift_fn = self._resolve_drift(drift)
         has_diffusion_fn = diffusion is not None
-        ns_const = self._resolve_diffusion(
-            None, noise_scale, x.device, x.dtype
-        ) if not has_diffusion_fn else None
+        ns_const = (
+            self._resolve_diffusion(None, noise_scale)
+            if not has_diffusion_fn
+            else None
+        )
         n = t_grid.numel() - 1
         batch_size = x.size(0)
         for i in range(n):

--- a/torchebm/core/base_loss.py
+++ b/torchebm/core/base_loss.py
@@ -20,6 +20,45 @@ from torchebm.core.base_module import warn_once
 logger = logging.getLogger(__name__)
 
 
+def _unexpected_init_args_message(cls, args, kwargs) -> str:
+    r"""Build the TypeError message for constructor arguments no loss accepts.
+
+    Walks `cls.__mro__` down to `BaseLoss` collecting every named constructor
+    parameter, so the message lists what the concrete loss actually supports,
+    including parameters bound by intermediate bases that the leaf signature
+    forwards through ``**kwargs``.
+    """
+    import inspect
+
+    from torchebm._version import __version__
+
+    supported: dict = {}
+    for klass in cls.__mro__:
+        init = klass.__dict__.get("__init__")
+        if init is not None:
+            for name, param in inspect.signature(init).parameters.items():
+                if name != "self" and param.kind not in (
+                    param.VAR_POSITIONAL,
+                    param.VAR_KEYWORD,
+                ):
+                    supported.setdefault(name)
+        if klass is BaseLoss:
+            break
+
+    problems = []
+    if kwargs:
+        problems.append(
+            "unexpected keyword argument(s) "
+            + ", ".join(repr(k) for k in kwargs)
+        )
+    if args:
+        problems.append(f"{len(args)} unexpected positional argument(s)")
+    return (
+        f"{cls.__name__}.__init__() got {' and '.join(problems)}. "
+        f"Supported parameters: {', '.join(supported)} (torchebm {__version__})."
+    )
+
+
 def _dtensor_type():
     try:
         from torch.distributed.tensor import DTensor
@@ -59,8 +98,16 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
         *args: Any,
         **kwargs: Any,
     ):
-        """Initialize the base loss class."""
-        super().__init__(device=device, dtype=dtype, *args, **kwargs)
+        """Initialize the base loss class.
+
+        Raises:
+            TypeError: If constructor arguments remain that no class in the
+                loss's MRO binds; the message lists the supported parameters
+                and the installed torchebm version.
+        """
+        if args or kwargs:
+            raise TypeError(_unexpected_init_args_message(type(self), args, kwargs))
+        super().__init__(device=device, dtype=dtype)
 
     def _resolve_model_kwargs(
         self,

--- a/torchebm/losses/equilibrium_matching.py
+++ b/torchebm/losses/equilibrium_matching.py
@@ -95,6 +95,12 @@ class EquilibriumMatchingLoss(BaseLoss):
         apply_dispersion: Whether to apply dispersive regularization.
         dispersion_weight: Weight for dispersive loss term.
         time_invariant: If True, pass zeros for time to model (EqM default).
+        check_time_conditioning: If True and ``time_invariant=False``, verify on
+            the first loss call that the model actually consumes its time input
+            (one probe pair: the same sample at two t values); a model that
+            ignores t raises a ValueError instead of silently training a
+            time-invariant field. Set False for models this probe misjudges,
+            e.g. stochastic-in-eval backbones. Default: True.
         dtype: Data type for computations.
         device: Device for computations.
 
@@ -142,6 +148,7 @@ class EquilibriumMatchingLoss(BaseLoss):
         apply_dispersion: bool = False,
         dispersion_weight: float = 0.5,
         time_invariant: bool = True,
+        check_time_conditioning: bool = True,
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
         *args,
@@ -175,6 +182,8 @@ class EquilibriumMatchingLoss(BaseLoss):
         self.apply_dispersion = apply_dispersion
         self.dispersion_weight = dispersion_weight
         self.time_invariant = time_invariant
+        self.check_time_conditioning = check_time_conditioning
+        self._time_check_pending = check_time_conditioning and not time_invariant
         self.interpolant = resolve_interpolant(
             interpolant, default="linear", owner="EquilibriumMatchingLoss"
         )
@@ -194,6 +203,54 @@ class EquilibriumMatchingLoss(BaseLoss):
         r"""Get training time interval respecting epsilon."""
         eps = self.train_eps
         return eps, 1.0 - eps
+
+    # Golden-ratio conjugate: no integer-frequency sinusoidal time embedding
+    # maps both probe times (0, this) to equal values, unlike 0.5 or 1.
+    _TIME_PROBE_T = 0.6180339887
+
+    def _probe_time_conditioning(
+        self, xt: torch.Tensor, model_kwargs: Dict[str, Any]
+    ) -> None:
+        r"""One-time check that the model consumes t when time_invariant=False.
+
+        Runs on the first loss call (input shape and conditioning are unknown
+        at construction): the same one-sample input at t=0 and t~0.618, model
+        temporarily in eval mode, gradients off. Identical outputs mean the
+        backbone drops its time input, so training would silently fit a
+        time-invariant field while the config claims otherwise.
+
+        Raises:
+            ValueError: If the outputs of the probe pair coincide.
+        """
+        probe_x = xt[:1].detach()
+        batch = xt.shape[0]
+        probe_kwargs = {
+            k: v[:1] if isinstance(v, torch.Tensor) and v.ndim > 0 and v.shape[0] == batch else v
+            for k, v in model_kwargs.items()
+        }
+        t0 = torch.zeros(1, device=probe_x.device, dtype=probe_x.dtype)
+        was_training = self.model.training
+        self.model.eval()
+        try:
+            with torch.no_grad():
+                out0 = self.model(probe_x, t0, **probe_kwargs)
+                out1 = self.model(
+                    probe_x, torch.full_like(t0, self._TIME_PROBE_T), **probe_kwargs
+                )
+        finally:
+            self.model.train(was_training)
+        if isinstance(out0, tuple):
+            out0 = out0[0]
+        if isinstance(out1, tuple):
+            out1 = out1[0]
+        if torch.allclose(out0, out1, rtol=1e-5, atol=1e-6):
+            raise ValueError(
+                f"{type(self.model).__name__} returns identical outputs at t=0 "
+                f"and t={self._TIME_PROBE_T:.3f}, so it ignores its time input "
+                "while time_invariant=False expects a time-conditioned field. "
+                "Wire t into the model, set time_invariant=True, or pass "
+                "check_time_conditioning=False to skip this probe."
+            )
 
     def _compute_ct(self, t: torch.Tensor) -> torch.Tensor:
         r"""Target scaling c(t) for the configured variant, times `ct_multiplier`."""
@@ -403,6 +460,10 @@ class EquilibriumMatchingLoss(BaseLoss):
         # For explicit energy, we need gradients w.r.t. xt
         if self.energy_type != "none":
             xt = xt.detach().requires_grad_(True)
+
+        if self._time_check_pending:
+            self._time_check_pending = False
+            self._probe_time_conditioning(xt, model_kwargs)
 
         # EqM: zero out time for time-invariance (model still receives t for API compat)
         t_model = torch.zeros_like(t) if self.time_invariant else t

--- a/torchebm/losses/equilibrium_matching.py
+++ b/torchebm/losses/equilibrium_matching.py
@@ -78,6 +78,20 @@ class EquilibriumMatchingLoss(BaseLoss):
             the source and target batches before interpolation.
         loss_weight: Loss weighting scheme ('velocity', 'likelihood', or None).
         train_eps: Epsilon for training time interval stability.
+        t_sampler: Training-time distribution:
+            - 'uniform' (default): uniform over the training interval
+            - 'lognormal': EDM timestep skew, $\sigma = e^{z p_{std} + p_{mean}}$
+              with $z \sim \mathcal{N}(0, 1)$ and $t = 1/(1+\sigma)$ clamped to
+              [1e-4, 1] (intersected with the ``train_eps`` interval)
+            - a callable ``(batch, *, device, dtype, generator) -> t`` returning
+              shape (batch_size,)
+        t_p_mean: Lognormal skew location $p_{mean}$ (EDM $P_{mean}$). Default: -1.2.
+        t_p_std: Lognormal skew scale $p_{std}$ (EDM $P_{std}$), positive. Default: 1.2.
+        loss_weight_fn: Optional per-timestep weight hook ``t -> w(t)`` (shape
+            (batch_size,)), multiplied into the per-sample loss before the
+            dispersion term; the mechanism behind min-SNR / EDM
+            $\lambda(\sigma)$ style weightings. None (default) keeps the loss
+            unweighted.
         ct: Weight family for the target scaling $c(t)$, always multiplied by
             ``ct_multiplier``:
             - 'truncated' (default): $\min(1, (1-t)/(1-a))$, the EqM truncated decay
@@ -94,13 +108,6 @@ class EquilibriumMatchingLoss(BaseLoss):
             is recorded on the loss (attribute and ``repr``). Default: 4.0.
         apply_dispersion: Whether to apply dispersive regularization.
         dispersion_weight: Weight for dispersive loss term.
-        time_invariant: If True, pass zeros for time to model (EqM default).
-        check_time_conditioning: If True and ``time_invariant=False``, verify on
-            the first loss call that the model actually consumes its time input
-            (one probe pair: the same sample at two t values); a model that
-            ignores t raises a ValueError instead of silently training a
-            time-invariant field. Set False for models this probe misjudges,
-            e.g. stochastic-in-eval backbones. Default: True.
         dtype: Data type for computations.
         device: Device for computations.
 
@@ -139,6 +146,13 @@ class EquilibriumMatchingLoss(BaseLoss):
         coupling: Union[str, BaseCoupling, None] = None,
         loss_weight: Optional[Literal["velocity", "likelihood"]] = None,
         train_eps: Union[float, BaseScheduler] = 0.0,
+        t_sampler: Union[
+            Literal["uniform", "lognormal"],
+            Callable[..., torch.Tensor],
+        ] = "uniform",
+        t_p_mean: float = -1.2,
+        t_p_std: float = 1.2,
+        loss_weight_fn: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
         ct: Union[
             Literal["truncated", "linear", "constant"],
             Callable[[torch.Tensor], torch.Tensor],
@@ -147,8 +161,6 @@ class EquilibriumMatchingLoss(BaseLoss):
         ct_multiplier: float = 4.0,
         apply_dispersion: bool = False,
         dispersion_weight: float = 0.5,
-        time_invariant: bool = True,
-        check_time_conditioning: bool = True,
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
         *args,
@@ -160,6 +172,18 @@ class EquilibriumMatchingLoss(BaseLoss):
             *args,
             **kwargs,
         )
+        if not callable(t_sampler) and t_sampler not in ("uniform", "lognormal"):
+            raise ValueError(
+                "t_sampler must be 'uniform', 'lognormal', or a callable "
+                f"(batch, *, device, dtype, generator) -> t, got {t_sampler!r}"
+            )
+        if t_p_std <= 0:
+            raise ValueError(f"t_p_std must be positive, got {t_p_std}")
+        if loss_weight_fn is not None and not callable(loss_weight_fn):
+            raise TypeError(
+                "loss_weight_fn must be callable or None, got "
+                f"{type(loss_weight_fn).__name__}"
+            )
         if not callable(ct) and ct not in ("truncated", "linear", "constant"):
             raise ValueError(
                 "ct must be 'truncated', 'linear', 'constant', or a callable "
@@ -175,15 +199,16 @@ class EquilibriumMatchingLoss(BaseLoss):
         self.prediction = prediction
         self.energy_type = energy_type
         self.loss_weight = loss_weight
+        self.t_sampler = t_sampler
+        self.t_p_mean = t_p_mean
+        self.t_p_std = t_p_std
+        self.loss_weight_fn = loss_weight_fn
         self._register_param("train_eps", train_eps)
         self.ct = ct
         self.ct_threshold = ct_threshold
         self.ct_multiplier = ct_multiplier
         self.apply_dispersion = apply_dispersion
         self.dispersion_weight = dispersion_weight
-        self.time_invariant = time_invariant
-        self.check_time_conditioning = check_time_conditioning
-        self._time_check_pending = check_time_conditioning and not time_invariant
         self.interpolant = resolve_interpolant(
             interpolant, default="linear", owner="EquilibriumMatchingLoss"
         )
@@ -204,53 +229,34 @@ class EquilibriumMatchingLoss(BaseLoss):
         eps = self.train_eps
         return eps, 1.0 - eps
 
-    # Golden-ratio conjugate: no integer-frequency sinusoidal time embedding
-    # maps both probe times (0, this) to equal values, unlike 0.5 or 1.
-    _TIME_PROBE_T = 0.6180339887
+    def _sample_t(
+        self, batch: int, generator: Optional[torch.Generator]
+    ) -> torch.Tensor:
+        r"""Draw training times for the configured `t_sampler`.
 
-    def _probe_time_conditioning(
-        self, xt: torch.Tensor, model_kwargs: Dict[str, Any]
-    ) -> None:
-        r"""One-time check that the model consumes t when time_invariant=False.
-
-        Runs on the first loss call (input shape and conditioning are unknown
-        at construction): the same one-sample input at t=0 and t~0.618, model
-        temporarily in eval mode, gradients off. Identical outputs mean the
-        backbone drops its time input, so training would silently fit a
-        time-invariant field while the config claims otherwise.
-
-        Raises:
-            ValueError: If the outputs of the probe pair coincide.
+        'lognormal' is the EDM timestep skew: \(\sigma = e^{z p_{std} + p_{mean}}\)
+        with \(z \sim \mathcal{N}(0, 1)\), \(t = 1/(1+\sigma)\), clamped into the
+        training interval with a 1e-4 floor. A callable receives
+        ``(batch, device=, dtype=, generator=)`` and must return shape (batch,).
         """
-        probe_x = xt[:1].detach()
-        batch = xt.shape[0]
-        probe_kwargs = {
-            k: v[:1] if isinstance(v, torch.Tensor) and v.ndim > 0 and v.shape[0] == batch else v
-            for k, v in model_kwargs.items()
-        }
-        t0 = torch.zeros(1, device=probe_x.device, dtype=probe_x.dtype)
-        was_training = self.model.training
-        self.model.eval()
-        try:
-            with torch.no_grad():
-                out0 = self.model(probe_x, t0, **probe_kwargs)
-                out1 = self.model(
-                    probe_x, torch.full_like(t0, self._TIME_PROBE_T), **probe_kwargs
-                )
-        finally:
-            self.model.train(was_training)
-        if isinstance(out0, tuple):
-            out0 = out0[0]
-        if isinstance(out1, tuple):
-            out1 = out1[0]
-        if torch.allclose(out0, out1, rtol=1e-5, atol=1e-6):
-            raise ValueError(
-                f"{type(self.model).__name__} returns identical outputs at t=0 "
-                f"and t={self._TIME_PROBE_T:.3f}, so it ignores its time input "
-                "while time_invariant=False expects a time-conditioned field. "
-                "Wire t into the model, set time_invariant=True, or pass "
-                "check_time_conditioning=False to skip this probe."
+        if callable(self.t_sampler):
+            return self.t_sampler(
+                batch, device=self.device, dtype=self.dtype, generator=generator
             )
+        t0, t1 = self._check_interval()
+        if self.t_sampler == "lognormal":
+            z = torch.randn(
+                batch, device=self.device, dtype=self.dtype, generator=generator
+            )
+            sigma = torch.exp(z * self.t_p_std + self.t_p_mean)
+            return (1.0 / (1.0 + sigma)).clamp(min=max(1.0e-4, t0), max=t1)
+        return (
+            torch.rand(
+                batch, device=self.device, dtype=self.dtype, generator=generator
+            )
+            * (t1 - t0)
+            + t0
+        )
 
     def _compute_ct(self, t: torch.Tensor) -> torch.Tensor:
         r"""Target scaling c(t) for the configured variant, times `ct_multiplier`."""
@@ -390,7 +396,7 @@ class EquilibriumMatchingLoss(BaseLoss):
 
         Implements gradient matching with EqM target:
         - Target: $(\epsilon - x) \cdot c(t) = (x_0 - x_1) \cdot c(t)$
-        - Time-invariant: zeros out time if time_invariant=True
+        - Time-invariant: the model always receives zeroed time
 
         Args:
             x1: Data samples of shape (batch_size, ...).
@@ -437,14 +443,7 @@ class EquilibriumMatchingLoss(BaseLoss):
         coupled = self.coupling(x0, x1, generator=generator, **model_kwargs)
         x0, x1 = coupled
 
-        t0, t1 = self._check_interval()
-        t = (
-            torch.rand(
-                batch, device=self.device, dtype=self.dtype, generator=generator
-            )
-            * (t1 - t0)
-            + t0
-        )
+        t = self._sample_t(batch, generator)
 
         # Interpolate: xt between x0 (noise) and x1 (data)
         xt, ut = self.interpolant.interpolate(x0, x1, t)
@@ -461,12 +460,8 @@ class EquilibriumMatchingLoss(BaseLoss):
         if self.energy_type != "none":
             xt = xt.detach().requires_grad_(True)
 
-        if self._time_check_pending:
-            self._time_check_pending = False
-            self._probe_time_conditioning(xt, model_kwargs)
-
         # EqM: zero out time for time-invariance (model still receives t for API compat)
-        t_model = torch.zeros_like(t) if self.time_invariant else t
+        t_model = torch.zeros_like(t)
 
         with self.autocast_context():
             model_output = self.model(xt, t_model, **model_kwargs)
@@ -517,6 +512,9 @@ class EquilibriumMatchingLoss(BaseLoss):
                 terms["loss"] = mean_flat(weight * (model_output * sigma_t + x0).square())
             else:
                 raise ValueError(f"Unknown prediction type: {self.prediction}")
+
+        if self.loss_weight_fn is not None:
+            terms["loss"] = terms["loss"] * self.loss_weight_fn(t)
 
         # Add dispersive regularization
         if self.apply_dispersion:

--- a/torchebm/losses/equilibrium_matching.py
+++ b/torchebm/losses/equilibrium_matching.py
@@ -27,7 +27,7 @@ Key differences from Flow Matching:
 
 from __future__ import annotations
 
-from typing import Dict, Literal, Optional, Any, Union
+from typing import Callable, Dict, Literal, Optional, Any, Union
 
 import torch
 from torch import nn
@@ -78,8 +78,20 @@ class EquilibriumMatchingLoss(BaseLoss):
             the source and target batches before interpolation.
         loss_weight: Loss weighting scheme ('velocity', 'likelihood', or None).
         train_eps: Epsilon for training time interval stability.
-        ct_threshold: Decay threshold $a$ for $c(t)$. Decay starts after $t > a$. Default: 0.8.
-        ct_multiplier: Gradient multiplier $\lambda$ for $c(t)$. Default: 4.0.
+        ct: Weight family for the target scaling $c(t)$, always multiplied by
+            ``ct_multiplier``:
+            - 'truncated' (default): $\min(1, (1-t)/(1-a))$, the EqM truncated decay
+            - 'linear': $1 - t$, the $a \to 0$ endpoint of the truncated dial
+            - 'constant': $1$, the $a \to 1$ endpoint; with ``ct_multiplier=1``
+              this is exactly the negated Flow Matching objective
+            - a callable ``t -> c(t)`` mapping a (batch_size,) time tensor to
+              weights of the same shape
+        ct_threshold: Decay threshold $a$ for ct='truncated', strictly inside
+            (0, 1); the endpoints are the 'linear' and 'constant' variants.
+            Decay starts after $t > a$. Default: 0.8.
+        ct_multiplier: Gradient multiplier $\lambda$ applied to every ct
+            variant. Samplers that rescale velocities divide it back out, so it
+            is recorded on the loss (attribute and ``repr``). Default: 4.0.
         apply_dispersion: Whether to apply dispersive regularization.
         dispersion_weight: Weight for dispersive loss term.
         time_invariant: If True, pass zeros for time to model (EqM default).
@@ -121,6 +133,10 @@ class EquilibriumMatchingLoss(BaseLoss):
         coupling: Union[str, BaseCoupling, None] = None,
         loss_weight: Optional[Literal["velocity", "likelihood"]] = None,
         train_eps: Union[float, BaseScheduler] = 0.0,
+        ct: Union[
+            Literal["truncated", "linear", "constant"],
+            Callable[[torch.Tensor], torch.Tensor],
+        ] = "truncated",
         ct_threshold: float = 0.8,
         ct_multiplier: float = 4.0,
         apply_dispersion: bool = False,
@@ -137,11 +153,23 @@ class EquilibriumMatchingLoss(BaseLoss):
             *args,
             **kwargs,
         )
+        if not callable(ct) and ct not in ("truncated", "linear", "constant"):
+            raise ValueError(
+                "ct must be 'truncated', 'linear', 'constant', or a callable "
+                f"t -> c(t), got {ct!r}"
+            )
+        if ct == "truncated" and not 0.0 < ct_threshold < 1.0:
+            raise ValueError(
+                f"ct_threshold must be in (0, 1) for ct='truncated', got "
+                f"{ct_threshold}; use ct='linear' for the threshold -> 0 "
+                "endpoint or ct='constant' for the threshold -> 1 endpoint"
+            )
         self.model = model
         self.prediction = prediction
         self.energy_type = energy_type
         self.loss_weight = loss_weight
         self._register_param("train_eps", train_eps)
+        self.ct = ct
         self.ct_threshold = ct_threshold
         self.ct_multiplier = ct_multiplier
         self.apply_dispersion = apply_dispersion
@@ -166,6 +194,18 @@ class EquilibriumMatchingLoss(BaseLoss):
         r"""Get training time interval respecting epsilon."""
         eps = self.train_eps
         return eps, 1.0 - eps
+
+    def _compute_ct(self, t: torch.Tensor) -> torch.Tensor:
+        r"""Target scaling c(t) for the configured variant, times `ct_multiplier`."""
+        if callable(self.ct):
+            return self.ct(t) * self.ct_multiplier
+        if self.ct == "truncated":
+            return compute_eqm_ct(
+                t, threshold=self.ct_threshold, multiplier=self.ct_multiplier
+            )
+        if self.ct == "linear":
+            return (1.0 - t) * self.ct_multiplier
+        return torch.full_like(t, self.ct_multiplier)
 
     def _reduce_dims(self, ndim: int) -> tuple:
         r"""Cached `tuple(range(1, ndim))` reduction dims (avoids per-call construction)."""
@@ -356,7 +396,7 @@ class EquilibriumMatchingLoss(BaseLoss):
         # For linear interpolant, -ut = x0 - x1 (equivalent to original formulation).
         # For VP/cosine, ut encodes the schedule-specific velocity coefficients.
         # Sampling with negate_velocity=True recovers the positive velocity ut*c(t).
-        ct = compute_eqm_ct(t, threshold=self.ct_threshold, multiplier=self.ct_multiplier)
+        ct = self._compute_ct(t)
         ct = ct.view(batch, *([1] * (xt.ndim - 1)))
         target = -ut * ct
 
@@ -429,7 +469,9 @@ class EquilibriumMatchingLoss(BaseLoss):
             f"prediction={self.prediction!r}, "
             f"energy_type={self.energy_type!r}, "
             f"interpolant={type(self.interpolant).__name__}, "
-            f"coupling={type(self.coupling).__name__})"
+            f"coupling={type(self.coupling).__name__}, "
+            f"ct={self.ct!r}, "
+            f"ct_multiplier={self.ct_multiplier})"
         )
 
 

--- a/torchebm/losses/loss_utils.py
+++ b/torchebm/losses/loss_utils.py
@@ -84,21 +84,25 @@ def compute_eqm_ct(
 
     Args:
         t: Time tensor of shape (batch_size,).
-        threshold: Decay threshold \(a\), decay starts after \(t > a\). Default: 0.8.
+        threshold: Decay threshold \(a\), decay starts after \(t > a\).
+            Must lie strictly inside (0, 1). Default: 0.8.
         multiplier: Gradient multiplier \(\lambda\). Default: 4.0.
 
     Returns:
         Scaling factor c(t) of same shape as t.
+
+    Raises:
+        ValueError: If `threshold` is not strictly inside (0, 1). The endpoint
+            behaviors are the ``'linear'`` (threshold to 0) and ``'constant'``
+            (threshold to 1) ``ct`` variants of `EquilibriumMatchingLoss`.
     """
-    start = 1.0
-    ct = (
-        torch.minimum(
-            start - (start - 1) / threshold * t,
-            1 / (1 - threshold) - 1 / (1 - threshold) * t,
+    if not 0.0 < threshold < 1.0:
+        raise ValueError(
+            f"threshold must be in (0, 1), got {threshold}; use the 'linear' "
+            "(threshold -> 0) or 'constant' (threshold -> 1) ct variant of "
+            "EquilibriumMatchingLoss for the endpoints"
         )
-        * multiplier
-    )
-    return ct
+    return ((1.0 - t) / (1.0 - threshold)).clamp(max=1.0) * multiplier
 
 
 def dispersive_loss(z: torch.Tensor) -> torch.Tensor:

--- a/torchebm/samplers/flow.py
+++ b/torchebm/samplers/flow.py
@@ -87,6 +87,9 @@ class FlowSampler(BaseSampler):
             `BaseScheduler` (advanced via `step_schedulers()`).
         negate_velocity: Negate the velocity during sampling. Set True for
             EqM models which learn (ε - x) direction; velocity is v = -f(x).
+            EqM equilibrium fields are time-invariant, so the model is then
+            conditioned on zeroed time (matching training) while the
+            integration clock still drives the grid and interpolant math.
         reverse: If True, integrate from data to noise (ODE mode only).
         diffusion_form: SDE-only. Form of the diffusion coefficient:
             'constant', 'SBDM' (default), 'sigma', 'linear', 'decreasing',
@@ -242,8 +245,12 @@ class FlowSampler(BaseSampler):
         r"""Get drift function for probability flow ODE."""
 
         def velocity_drift(x, t, **model_kwargs):
-            v = self.model(x, t, **model_kwargs)
-            return -v if self.negate_velocity else v
+            if self.negate_velocity:
+                # EqM equilibrium fields are time-invariant: trained with
+                # zeroed time, so the model is conditioned on zeros here too;
+                # t still drives the integration grid.
+                return -self.model(x, torch.zeros_like(t), **model_kwargs)
+            return self.model(x, t, **model_kwargs)
 
         def score_drift(x, t, **model_kwargs):
             drift_mean, drift_var = self.interpolant.compute_drift(x, t)
@@ -269,7 +276,12 @@ class FlowSampler(BaseSampler):
         r"""Get score function from model output."""
 
         def velocity_score(x, t, **model_kwargs):
-            velocity = self.model(x, t, **model_kwargs)
+            if self.negate_velocity:
+                # Match velocity_drift: the sampling velocity is v = -f with
+                # the field evaluated at zeroed time.
+                velocity = -self.model(x, torch.zeros_like(t), **model_kwargs)
+            else:
+                velocity = self.model(x, t, **model_kwargs)
             return self.interpolant.velocity_to_score(velocity, x, t)
 
         def score_score(x, t, **model_kwargs):


### PR DESCRIPTION
Loss constructors reject unknown kwargs with a TypeError listing the supported parameters and the installed version, instead of the bare nn.Module error.

EquilibriumMatchingLoss gains a pluggable c(t) weight family (truncated, linear, constant, or a callable; constant with unit multiplier is exactly the negated Flow Matching objective, pinned by a value-and-gradient test against a reference FM implementation), the EDM lognormal timestep skew via t_sampler with a callable escape hatch, and a per-timestep loss weight hook loss_weight_fn(t) for min-SNR / EDM-lambda style weightings. Truncated-decay threshold endpoints now raise a clear ValueError instead of ZeroDivisionError.

EqM is time-invariant end to end: the loss always conditions the model on zeroed time, and FlowSampler(negate_velocity=True) now does the same during sampling (previously it passed the integration clock; the SDE score path also derived the score from the un-negated field and is fixed to use v = -f).

resolves #253, resolves #254, resolves #255, resolves #256, resolves #257