### PR TITLE
feat(conditioning): class-conditional training and classifier-free guidance

### DIFF
--- a/tests/losses/test_cfg_dropout.py
+++ b/tests/losses/test_cfg_dropout.py
@@ -1,0 +1,166 @@
+"""Classifier-free-guidance label dropout on loss forwards.
+
+cfg_dropout replaces y with the null condition per sample during training;
+eval mode and the unconditional path are untouched.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from torchebm.core import BaseModel
+from torchebm.losses import (
+    ContrastiveDivergence,
+    DenoisingScoreMatching,
+    EnergyMatchingLoss,
+    EquilibriumMatchingLoss,
+    ScoreMatching,
+)
+from torchebm.samplers import LangevinDynamics
+
+NUM_CLASSES = 5
+
+
+class RecordingPotential(BaseModel):
+    def __init__(self, dim=4):
+        super().__init__()
+        self.linear = nn.Linear(dim, 1)
+        self.received_y = None
+
+    def forward(self, x, t=None, y=None, **kwargs):
+        self.received_y = y
+        out = self.linear(x).squeeze(-1)
+        if y is not None:
+            out = out + y.view(y.shape[0], -1).float().sum(dim=1)
+        return out
+
+
+class RecordingField(nn.Module):
+    def __init__(self, dim=4):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim)
+        self.received_y = None
+
+    def forward(self, x, t=None, y=None, **kwargs):
+        self.received_y = y
+        out = self.linear(x)
+        if y is not None:
+            out = out + y.view(y.shape[0], -1).float().sum(dim=1, keepdim=True)
+        return out
+
+
+def _cd(model, **kw):
+    return ContrastiveDivergence(
+        model=model, sampler=LangevinDynamics(model=model), k_steps=2, **kw
+    )
+
+
+LOSSES = [
+    pytest.param(RecordingField, EquilibriumMatchingLoss, id="EquilibriumMatchingLoss"),
+    pytest.param(
+        RecordingPotential,
+        lambda model, **kw: EnergyMatchingLoss(model=model, lambda_cd=0.0, **kw),
+        id="EnergyMatchingLoss",
+    ),
+    pytest.param(
+        RecordingPotential,
+        lambda model, **kw: ScoreMatching(model=model, hessian_method="approx", **kw),
+        id="ScoreMatching-approx",
+    ),
+    pytest.param(RecordingPotential, DenoisingScoreMatching, id="DenoisingScoreMatching"),
+    pytest.param(RecordingPotential, _cd, id="ContrastiveDivergence"),
+]
+
+
+@pytest.mark.parametrize("model_cls,factory", LOSSES)
+def test_cfg_dropout_one_replaces_every_label(model_cls, factory):
+    model = model_cls()
+    loss_fn = factory(model, cfg_dropout=1.0, null_condition=NUM_CLASSES)
+    loss_fn.train()
+    y = torch.randint(0, NUM_CLASSES, (8,))
+    loss_fn(torch.randn(8, 4), y=y)
+    assert torch.all(model.received_y == NUM_CLASSES)
+
+
+@pytest.mark.parametrize("model_cls,factory", LOSSES)
+def test_cfg_dropout_zero_keeps_labels(model_cls, factory):
+    model = model_cls()
+    loss_fn = factory(model)
+    loss_fn.train()
+    y = torch.randint(0, NUM_CLASSES, (8,))
+    loss_fn(torch.randn(8, 4), y=y)
+    assert torch.equal(model.received_y, y.to(model.received_y.device))
+
+
+def test_cfg_dropout_inactive_in_eval_mode():
+    model = RecordingField()
+    loss_fn = EquilibriumMatchingLoss(
+        model=model, cfg_dropout=1.0, null_condition=NUM_CLASSES
+    )
+    loss_fn.eval()
+    y = torch.randint(0, NUM_CLASSES, (8,))
+    loss_fn(torch.randn(8, 4), y=y)
+    assert torch.equal(model.received_y, y)
+
+
+def test_cfg_dropout_mask_is_generator_deterministic():
+    model = RecordingField()
+    loss_fn = EquilibriumMatchingLoss(
+        model=model, cfg_dropout=0.5, null_condition=NUM_CLASSES
+    )
+    loss_fn.train()
+    x = torch.randn(64, 4)
+    y = torch.randint(0, NUM_CLASSES, (64,))
+    loss_fn(x, y=y, generator=torch.Generator().manual_seed(7))
+    first = model.received_y.clone()
+    loss_fn(x, y=y, generator=torch.Generator().manual_seed(7))
+    assert torch.equal(first, model.received_y)
+    dropped = (first == NUM_CLASSES) & (y != NUM_CLASSES)
+    assert dropped.any() and not dropped.all()
+    assert torch.equal(first[~dropped], y[~dropped])
+
+
+def test_cfg_dropout_tensor_null_for_embeddings():
+    model = RecordingField()
+    loss_fn = EquilibriumMatchingLoss(
+        model=model, cfg_dropout=1.0, null_condition=torch.zeros(3)
+    )
+    loss_fn.train()
+    y = torch.randn(8, 3)
+    loss_fn(torch.randn(8, 4), y=y)
+    assert torch.all(model.received_y == 0)
+    assert model.received_y.shape == y.shape
+
+
+def test_cfg_dropout_callable_null():
+    def null_fn(y, mask):
+        return torch.where(mask, torch.full_like(y, -1), y)
+
+    model = RecordingField()
+    loss_fn = EquilibriumMatchingLoss(
+        model=model, cfg_dropout=1.0, null_condition=null_fn
+    )
+    loss_fn.train()
+    y = torch.randint(0, NUM_CLASSES, (8,))
+    loss_fn(torch.randn(8, 4), y=y)
+    assert torch.all(model.received_y == -1)
+
+
+def test_cfg_dropout_noop_without_y():
+    loss_fn = EquilibriumMatchingLoss(
+        model=RecordingField(), cfg_dropout=0.5, null_condition=NUM_CLASSES
+    )
+    loss_fn.train()
+    assert torch.isfinite(loss_fn(torch.randn(8, 4)))
+
+
+def test_cfg_dropout_out_of_range_raises():
+    with pytest.raises(ValueError, match="cfg_dropout"):
+        EquilibriumMatchingLoss(
+            model=RecordingField(), cfg_dropout=1.5, null_condition=NUM_CLASSES
+        )
+
+
+def test_cfg_dropout_requires_null_condition():
+    with pytest.raises(ValueError, match="null_condition"):
+        EquilibriumMatchingLoss(model=RecordingField(), cfg_dropout=0.1)

--- a/tests/losses/test_condition_probe.py
+++ b/tests/losses/test_condition_probe.py
@@ -1,0 +1,135 @@
+"""Contract probe: a model handed y must actually consume it.
+
+On the first conditional loss call, the same input is evaluated under two
+distinct in-batch y values; identical outputs mean the backbone silently
+drops its conditioning and training would produce an unconditional model.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from torchebm.core import BaseModel
+from torchebm.losses import (
+    ContrastiveDivergence,
+    DenoisingScoreMatching,
+    EnergyMatchingLoss,
+    EquilibriumMatchingLoss,
+    ScoreMatching,
+)
+from torchebm.samplers import LangevinDynamics
+
+
+class IgnoringPotential(BaseModel):
+    def __init__(self, dim=4):
+        super().__init__()
+        self.linear = nn.Linear(dim, 1)
+
+    def forward(self, x, t=None, y=None, **kwargs):
+        return self.linear(x).squeeze(-1)
+
+
+class IgnoringField(nn.Module):
+    def __init__(self, dim=4):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim)
+
+    def forward(self, x, t=None, y=None, **kwargs):
+        return self.linear(x)
+
+
+class ConsumingField(nn.Module):
+    def __init__(self, dim=4):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim)
+        self.calls = 0
+
+    def forward(self, x, t=None, y=None, **kwargs):
+        self.calls += 1
+        out = self.linear(x)
+        if y is not None:
+            out = out + y.view(y.shape[0], -1).float().sum(dim=1, keepdim=True)
+        return out
+
+
+def _cd(model, **kw):
+    return ContrastiveDivergence(
+        model=model, sampler=LangevinDynamics(model=model), k_steps=2, **kw
+    )
+
+
+LOSSES = [
+    pytest.param(IgnoringField, EquilibriumMatchingLoss, id="EquilibriumMatchingLoss"),
+    pytest.param(
+        IgnoringPotential,
+        lambda model, **kw: EnergyMatchingLoss(model=model, lambda_cd=0.0, **kw),
+        id="EnergyMatchingLoss",
+    ),
+    pytest.param(
+        IgnoringPotential,
+        lambda model, **kw: ScoreMatching(model=model, hessian_method="approx", **kw),
+        id="ScoreMatching-approx",
+    ),
+    pytest.param(IgnoringPotential, DenoisingScoreMatching, id="DenoisingScoreMatching"),
+    pytest.param(IgnoringPotential, _cd, id="ContrastiveDivergence"),
+]
+
+
+def _distinct_y(batch=8):
+    y = torch.zeros(batch, dtype=torch.long)
+    y[batch // 2 :] = 1
+    return y
+
+
+@pytest.mark.parametrize("model_cls,factory", LOSSES)
+def test_ignoring_model_raises(model_cls, factory):
+    model = model_cls()
+    loss_fn = factory(model)
+    with pytest.raises(ValueError, match=type(model).__name__):
+        loss_fn(torch.randn(8, 4), y=_distinct_y())
+
+
+def test_consuming_model_passes():
+    loss_fn = EquilibriumMatchingLoss(model=ConsumingField())
+    assert torch.isfinite(loss_fn(torch.randn(8, 4), y=_distinct_y()))
+
+
+def test_opt_out_flag_skips_probe():
+    loss_fn = EquilibriumMatchingLoss(
+        model=IgnoringField(), check_conditioning=False
+    )
+    assert torch.isfinite(loss_fn(torch.randn(8, 4), y=_distinct_y()))
+
+
+def test_probe_runs_once():
+    model = ConsumingField()
+    loss_fn = EquilibriumMatchingLoss(model=model)
+    loss_fn(torch.randn(8, 4), y=_distinct_y())
+    assert model.calls == 3  # probe pair + training forward
+    loss_fn(torch.randn(8, 4), y=_distinct_y())
+    assert model.calls == 4
+
+
+def test_unconditional_path_never_probes():
+    model = ConsumingField()
+    loss_fn = EquilibriumMatchingLoss(model=model)
+    loss_fn(torch.randn(8, 4))
+    assert model.calls == 1
+
+
+def test_uniform_labels_warn_and_disarm():
+    model = IgnoringField()
+    loss_fn = EquilibriumMatchingLoss(model=model)
+    y_uniform = torch.zeros(8, dtype=torch.long)
+    with pytest.warns(UserWarning, match="[Cc]ould not"):
+        loss_fn(torch.randn(8, 4), y=y_uniform)
+    # Disarmed: a later distinct batch must not raise.
+    assert torch.isfinite(loss_fn(torch.randn(8, 4), y=_distinct_y()))
+
+
+def test_probe_restores_training_mode():
+    model = ConsumingField()
+    model.train()
+    loss_fn = EquilibriumMatchingLoss(model=model)
+    loss_fn(torch.randn(8, 4), y=_distinct_y())
+    assert model.training

--- a/tests/losses/test_conditional_y.py
+++ b/tests/losses/test_conditional_y.py
@@ -1,0 +1,165 @@
+"""Explicit y= conditioning passthrough on loss forwards.
+
+y is forwarded to the model as model(x, t, y=y) (an alias into the
+model_kwargs channel), y=None keeps the unconditional path identical, and
+passing y both ways at once fails loudly.
+"""
+
+import unittest.mock
+
+import pytest
+import torch
+import torch.nn as nn
+
+from torchebm.core import BaseModel
+from torchebm.losses import (
+    ContrastiveDivergence,
+    DenoisingScoreMatching,
+    EnergyMatchingLoss,
+    EquilibriumMatchingLoss,
+    ScoreMatching,
+    SlicedScoreMatching,
+)
+from torchebm.samplers import LangevinDynamics
+
+
+class RecordingPotential(BaseModel):
+    """Scalar energy that records the y it receives."""
+
+    def __init__(self, dim=4):
+        super().__init__()
+        self.linear = nn.Linear(dim, 1)
+        self.received_y = None
+
+    def forward(self, x, t=None, y=None, **kwargs):
+        self.received_y = y
+        out = self.linear(x).squeeze(-1)
+        if y is not None:
+            out = out + y.view(y.shape[0], -1).float().sum(dim=1)
+        return out
+
+
+class RecordingField(nn.Module):
+    """Vector field that records the y it receives."""
+
+    def __init__(self, dim=4):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim)
+        self.received_y = None
+
+    def forward(self, x, t=None, y=None, **kwargs):
+        self.received_y = y
+        out = self.linear(x)
+        if y is not None:
+            out = out + y.view(y.shape[0], *([1] * (x.ndim - 1))).float()
+        return out
+
+
+def _cd(model):
+    return ContrastiveDivergence(
+        model=model, sampler=LangevinDynamics(model=model), k_steps=2
+    )
+
+
+LOSSES = [
+    pytest.param(RecordingField, EquilibriumMatchingLoss, id="EquilibriumMatchingLoss"),
+    pytest.param(
+        RecordingPotential,
+        lambda model: EnergyMatchingLoss(model=model, lambda_cd=0.0),
+        id="EnergyMatchingLoss",
+    ),
+    pytest.param(
+        RecordingPotential,
+        lambda model: ScoreMatching(model=model, hessian_method="approx"),
+        id="ScoreMatching-approx",
+    ),
+    pytest.param(RecordingPotential, DenoisingScoreMatching, id="DenoisingScoreMatching"),
+    pytest.param(RecordingPotential, _cd, id="ContrastiveDivergence"),
+]
+
+UNSUPPORTED = [
+    pytest.param(ScoreMatching, id="ScoreMatching-exact"),
+    pytest.param(SlicedScoreMatching, id="SlicedScoreMatching"),
+]
+
+
+@pytest.mark.parametrize("loss_cls", UNSUPPORTED)
+def test_y_surfaces_unsupported_conditioning_error(loss_cls):
+    """Losses that reject conditioning reject y= the same clear way."""
+    loss_fn = loss_cls(model=RecordingPotential())
+    with pytest.raises(NotImplementedError, match="[Cc]onditional"):
+        loss_fn(torch.randn(8, 4), y=torch.randint(0, 3, (8,)))
+
+
+def _loss_of(result):
+    return result[0] if isinstance(result, tuple) else result
+
+
+@pytest.mark.parametrize("model_cls,factory", LOSSES)
+def test_y_reaches_the_model(model_cls, factory):
+    model = model_cls()
+    loss_fn = factory(model)
+    y = torch.randint(0, 3, (8,))
+    loss = _loss_of(loss_fn(torch.randn(8, 4), y=y))
+    assert torch.isfinite(loss)
+    assert model.received_y is not None
+    assert torch.equal(model.received_y, y.to(model.received_y.device))
+
+
+@pytest.mark.parametrize("model_cls,factory", LOSSES)
+def test_y_equivalent_to_model_kwargs(model_cls, factory):
+    model = model_cls()
+    loss_fn = factory(model)
+    x = torch.randn(8, 4)
+    y = torch.randint(0, 3, (8,))
+    loss_sugar = _loss_of(
+        loss_fn(x, y=y, generator=torch.Generator().manual_seed(3))
+    )
+    loss_explicit = _loss_of(
+        loss_fn(
+            x, model_kwargs={"y": y}, generator=torch.Generator().manual_seed(3)
+        )
+    )
+    assert torch.equal(loss_sugar, loss_explicit)
+
+
+@pytest.mark.parametrize("model_cls,factory", LOSSES)
+def test_y_none_is_identical_to_omitting(model_cls, factory):
+    model = model_cls()
+    loss_fn = factory(model)
+    x = torch.randn(8, 4)
+    loss_none = _loss_of(loss_fn(x, y=None, generator=torch.Generator().manual_seed(5)))
+    loss_omitted = _loss_of(loss_fn(x, generator=torch.Generator().manual_seed(5)))
+    assert torch.equal(loss_none, loss_omitted)
+    assert model.received_y is None
+
+
+def test_y_does_not_trigger_deprecated_kwargs_path():
+    loss_fn = EquilibriumMatchingLoss(model=RecordingField())
+    with unittest.mock.patch("torchebm.core.base_loss.warn_once") as warn:
+        loss_fn(torch.randn(4, 4), y=torch.randint(0, 3, (4,)))
+    warn.assert_not_called()
+
+
+def test_y_conflict_with_model_kwargs_raises():
+    loss_fn = EquilibriumMatchingLoss(model=RecordingField())
+    y = torch.randint(0, 3, (4,))
+    with pytest.raises(ValueError, match="model_kwargs"):
+        loss_fn(torch.randn(4, 4), y=y, model_kwargs={"y": y})
+
+
+def test_conditional_model_trains():
+    model = RecordingField()
+    loss_fn = EquilibriumMatchingLoss(model=model)
+    optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+    y = torch.randint(0, 3, (16,))
+    for _ in range(3):
+        optimizer.zero_grad()
+        loss = loss_fn(torch.randn(16, 4), y=y)
+        loss.backward()
+        optimizer.step()
+    assert torch.isfinite(loss)
+    assert all(
+        p.grad is not None and torch.isfinite(p.grad).all()
+        for p in model.parameters()
+    )

--- a/tests/models/test_cfg_wrapper.py
+++ b/tests/models/test_cfg_wrapper.py
@@ -1,0 +1,171 @@
+"""ClassifierFreeGuidance wrapper: one batched forward, every sampler."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from torchebm.core import BaseModel
+from torchebm.models import ClassifierFreeGuidance
+from torchebm.samplers import FlowSampler, LangevinDynamics
+
+NUM_CLASSES = 5
+
+
+class CountingField(nn.Module):
+    """Conditional field with a strong y dependence; counts calls."""
+
+    def __init__(self, dim=2):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim)
+        self.embed = nn.Embedding(NUM_CLASSES + 1, dim)
+        self.calls = 0
+        self.batch_sizes = []
+
+    def forward(self, x, t=None, y=None, **kwargs):
+        self.calls += 1
+        self.batch_sizes.append(x.shape[0])
+        out = self.linear(x)
+        if y is not None:
+            out = out + self.embed(y)
+        return out
+
+
+class ConditionalEnergy(BaseModel):
+    def __init__(self, dim=2):
+        super().__init__()
+        self.linear = nn.Linear(dim, 1)
+        self.embed = nn.Embedding(NUM_CLASSES + 1, dim)
+
+    def forward(self, x, y=None, **kwargs):
+        shift = self.embed(y) if y is not None else 0.0
+        return 0.5 * (x - shift).square().sum(dim=1) + self.linear(x).squeeze(-1)
+
+
+def test_w_zero_equals_null_condition_forward():
+    field = CountingField()
+    guided = ClassifierFreeGuidance(
+        field, guidance_scale=0.0, null_condition=NUM_CLASSES
+    )
+    x = torch.randn(6, 2)
+    t = torch.rand(6)
+    y = torch.randint(0, NUM_CLASSES, (6,))
+    out = guided(x, t, y=y)
+    expected = field(x, t, y=torch.full_like(y, NUM_CLASSES))
+    assert torch.equal(out, expected)
+
+
+def test_w_one_matches_conditional_forward():
+    field = CountingField()
+    guided = ClassifierFreeGuidance(
+        field, guidance_scale=1.0, null_condition=NUM_CLASSES
+    )
+    x = torch.randn(6, 2)
+    t = torch.rand(6)
+    y = torch.randint(0, NUM_CLASSES, (6,))
+    assert torch.allclose(guided(x, t, y=y), field(x, t, y=y), atol=1e-6)
+
+
+def test_single_doubled_forward():
+    field = CountingField()
+    guided = ClassifierFreeGuidance(
+        field, guidance_scale=2.0, null_condition=NUM_CLASSES
+    )
+    x = torch.randn(6, 2)
+    guided(x, torch.rand(6), y=torch.randint(0, NUM_CLASSES, (6,)))
+    assert field.calls == 1
+    assert field.batch_sizes == [12]
+
+
+def test_guidance_formula():
+    field = CountingField()
+    w = 3.0
+    guided = ClassifierFreeGuidance(field, guidance_scale=w, null_condition=NUM_CLASSES)
+    x = torch.randn(6, 2)
+    t = torch.rand(6)
+    y = torch.randint(0, NUM_CLASSES, (6,))
+    out = guided(x, t, y=y)
+    cond = field(x, t, y=y)
+    uncond = field(x, t, y=torch.full_like(y, NUM_CLASSES))
+    assert torch.allclose(out, uncond + w * (cond - uncond), atol=1e-6)
+
+
+def test_unconditional_passthrough_without_y():
+    field = CountingField()
+    guided = ClassifierFreeGuidance(
+        field, guidance_scale=2.0, null_condition=NUM_CLASSES
+    )
+    x = torch.randn(6, 2)
+    t = torch.rand(6)
+    out = guided(x, t)
+    assert field.batch_sizes == [6]
+    assert torch.equal(out, field(x, t))
+
+
+def test_tensor_null_condition():
+    class EmbField(nn.Module):
+        def forward(self, x, t=None, y=None, **kwargs):
+            return x + y
+
+    guided = ClassifierFreeGuidance(
+        EmbField(), guidance_scale=0.0, null_condition=torch.zeros(2)
+    )
+    x = torch.randn(6, 2)
+    out = guided(x, torch.rand(6), y=torch.randn(6, 2))
+    assert torch.equal(out, x)
+
+
+def test_flow_sampler_w_zero_equals_null_labeled_sampling():
+    field = CountingField()
+    guided = ClassifierFreeGuidance(
+        field, guidance_scale=0.0, null_condition=NUM_CLASSES
+    )
+    y = torch.randint(0, NUM_CLASSES, (4,))
+    null_y = torch.full_like(y, NUM_CLASSES)
+
+    s_guided = FlowSampler(guided, integrator="euler")
+    s_plain = FlowSampler(field, integrator="euler")
+
+    x0 = torch.randn(4, 2)
+    out_guided = s_guided.sample(
+        x=x0.clone(), n_steps=5, model_kwargs={"y": y}
+    )
+    out_plain = s_plain.sample(
+        x=x0.clone(), n_steps=5, model_kwargs={"y": null_y}
+    )
+    assert torch.allclose(out_guided, out_plain, atol=1e-6)
+
+
+def test_langevin_w_zero_equals_null_labeled_sampling():
+    energy = ConditionalEnergy()
+    guided = ClassifierFreeGuidance(
+        energy, guidance_scale=0.0, null_condition=NUM_CLASSES
+    )
+    y = torch.randint(0, NUM_CLASSES, (4,))
+    null_y = torch.full_like(y, NUM_CLASSES)
+
+    x0 = torch.randn(4, 2)
+    out_guided = LangevinDynamics(guided, step_size=0.01).sample(
+        x=x0.clone(),
+        n_steps=10,
+        model_kwargs={"y": y},
+        generator=torch.Generator().manual_seed(3),
+    )
+    out_plain = LangevinDynamics(energy, step_size=0.01).sample(
+        x=x0.clone(),
+        n_steps=10,
+        model_kwargs={"y": null_y},
+        generator=torch.Generator().manual_seed(3),
+    )
+    assert torch.allclose(out_guided, out_plain, atol=1e-6)
+
+
+def test_langevin_guided_sampling_runs_with_positive_scale():
+    energy = ConditionalEnergy()
+    guided = ClassifierFreeGuidance(
+        energy, guidance_scale=2.5, null_condition=NUM_CLASSES
+    )
+    y = torch.randint(0, NUM_CLASSES, (4,))
+    out = LangevinDynamics(guided, step_size=0.01).sample(
+        x=torch.randn(4, 2), n_steps=10, model_kwargs={"y": y}
+    )
+    assert torch.isfinite(out).all()

--- a/tests/models/test_wrappers.py
+++ b/tests/models/test_wrappers.py
@@ -3,7 +3,7 @@ import torch
 from torch import nn
 
 from torchebm.core import BaseModel, TemperatureScheduler
-from torchebm.models.wrappers import InteractionModel, LabelClassifierFreeGuidance
+from torchebm.models.wrappers import ClassifierFreeGuidance, InteractionModel
 from torchebm.samplers import LangevinDynamics
 
 
@@ -13,18 +13,16 @@ class _DummyBase(nn.Module):
         self.null_id = null_id
         self.out_channels = out_channels
 
-    def forward(self, x, t, *, y):
+    def forward(self, x, t, y=None, **kwargs):
         b, _, h, w = x.shape
         base = torch.zeros(b, self.out_channels, h, w)
         cond_marker = (y != self.null_id).float().view(b, 1, 1, 1)
         return base + cond_marker
 
 
-def test_cfg_scale_one_returns_base_forward():
+def test_cfg_scale_one_matches_base_forward():
     base = _DummyBase(null_id=10)
-    wrapped = LabelClassifierFreeGuidance(
-        base, null_label_id=10, cfg_scale=1.0, guide_channels=3
-    )
+    wrapped = ClassifierFreeGuidance(base, guidance_scale=1.0, null_condition=10)
     x = torch.randn(2, 3, 4, 4)
     t = torch.rand(2)
     y = torch.tensor([1, 2])
@@ -34,8 +32,8 @@ def test_cfg_scale_one_returns_base_forward():
 
 def test_cfg_applies_guidance_to_first_channels_only():
     base = _DummyBase(null_id=10, out_channels=4)
-    wrapped = LabelClassifierFreeGuidance(
-        base, null_label_id=10, cfg_scale=2.0, guide_channels=3
+    wrapped = ClassifierFreeGuidance(
+        base, guidance_scale=2.0, null_condition=10, guide_channels=3
     )
     x = torch.randn(1, 3, 4, 4)
     t = torch.rand(1)
@@ -50,8 +48,8 @@ def test_cfg_applies_guidance_to_first_channels_only():
 
 def test_cfg_guide_channels_exceeds_output_clamps():
     base = _DummyBase(null_id=5, out_channels=2)
-    wrapped = LabelClassifierFreeGuidance(
-        base, null_label_id=5, cfg_scale=3.0, guide_channels=10
+    wrapped = ClassifierFreeGuidance(
+        base, guidance_scale=3.0, null_condition=5, guide_channels=10
     )
     x = torch.randn(1, 3, 2, 2)
     t = torch.rand(1)

--- a/tests/samplers/test_sampler_y_passthrough.py
+++ b/tests/samplers/test_sampler_y_passthrough.py
@@ -1,0 +1,111 @@
+"""Explicit y= conditioning on sampler sample(), mirroring the loss surface."""
+
+import warnings
+
+import pytest
+import torch
+import torch.nn as nn
+
+from torchebm.core import BaseModel
+from torchebm.samplers import (
+    FlowSampler,
+    GradientDescentSampler,
+    HamiltonianMonteCarlo,
+    LangevinDynamics,
+    NesterovSampler,
+)
+
+
+class CondField(nn.Module):
+    def __init__(self, dim=2):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim)
+        self.received_y = None
+
+    def forward(self, x, t=None, y=None, **kwargs):
+        self.received_y = y
+        out = self.linear(x)
+        if y is not None:
+            out = out + y.view(-1, 1).float()
+        return out
+
+
+class CondEnergy(BaseModel):
+    def __init__(self, dim=2):
+        super().__init__()
+        self.linear = nn.Linear(dim, 1)
+        self.received_y = None
+
+    def forward(self, x, y=None, **kwargs):
+        self.received_y = y
+        out = 0.5 * x.square().sum(dim=1) + self.linear(x).squeeze(-1)
+        if y is not None:
+            out = out + y.float()
+        return out
+
+
+SAMPLERS = [
+    pytest.param(
+        CondField,
+        lambda m: FlowSampler(m, integrator="euler"),
+        id="FlowSampler",
+    ),
+    pytest.param(
+        CondEnergy,
+        lambda m: LangevinDynamics(m, step_size=0.01),
+        id="LangevinDynamics",
+    ),
+    pytest.param(
+        CondEnergy,
+        lambda m: HamiltonianMonteCarlo(m, step_size=0.01, n_leapfrog_steps=3),
+        id="HamiltonianMonteCarlo",
+    ),
+    pytest.param(
+        CondEnergy,
+        lambda m: GradientDescentSampler(m, step_size=0.01),
+        id="GradientDescentSampler",
+    ),
+    pytest.param(
+        CondEnergy,
+        lambda m: NesterovSampler(m, step_size=0.01),
+        id="NesterovSampler",
+    ),
+]
+
+
+@pytest.mark.parametrize("model_cls,factory", SAMPLERS)
+def test_sample_y_equivalent_to_model_kwargs(model_cls, factory):
+    y = torch.randint(0, 3, (4,))
+    x0 = torch.randn(4, 2)
+
+    model_a = model_cls()
+    out_sugar = factory(model_a).sample(
+        x=x0.clone(), n_steps=3, y=y, generator=torch.Generator().manual_seed(9)
+    )
+    state = model_a.state_dict()
+
+    model_b = model_cls()
+    model_b.load_state_dict(state)
+    out_explicit = factory(model_b).sample(
+        x=x0.clone(),
+        n_steps=3,
+        model_kwargs={"y": y},
+        generator=torch.Generator().manual_seed(9),
+    )
+    assert torch.equal(out_sugar, out_explicit)
+    assert model_a.received_y is not None
+
+
+@pytest.mark.parametrize("model_cls,factory", SAMPLERS)
+def test_sample_y_emits_no_deprecation_warning(model_cls, factory):
+    sampler = factory(model_cls())
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        sampler.sample(x=torch.randn(4, 2), n_steps=2, y=torch.randint(0, 3, (4,)))
+
+
+def test_sample_y_conflict_raises():
+    sampler = LangevinDynamics(CondEnergy(), step_size=0.01)
+    y = torch.randint(0, 3, (4,))
+    with pytest.raises(ValueError, match="model_kwargs"):
+        sampler.sample(x=torch.randn(4, 2), n_steps=2, y=y, model_kwargs={"y": y})

--- a/tests/test_conditioning.py
+++ b/tests/test_conditioning.py
@@ -190,8 +190,8 @@ def test_flow_bare_kwargs_deprecated_but_works():
     field = RecordingField()
     sampler = FlowSampler(field, interpolant="linear", integrator="euler")
     with pytest.warns(DeprecationWarning):
-        sampler.sample(x=torch.randn(4, 2), n_steps=2, y=_labels(4))
-    assert field.seen and all(rec is not None for rec in field.seen)
+        sampler.sample(x=torch.randn(4, 2), n_steps=2, cond=_labels(4))
+    assert field.seen
 
 
 def test_eqm_bare_kwargs_deprecated():

--- a/tests/test_conditioning.py
+++ b/tests/test_conditioning.py
@@ -50,7 +50,10 @@ class RecordingEnergy(BaseModel):
 
     def forward(self, x, y=None):
         self.seen.append(None if y is None else (y.dtype, tuple(y.shape)))
-        return self.scale * (x**2).sum(dim=-1)
+        out = self.scale * (x**2).sum(dim=-1)
+        if y is not None:
+            out = out + y.float()
+        return out
 
 
 class RecordingField(nn.Module):
@@ -63,7 +66,10 @@ class RecordingField(nn.Module):
 
     def forward(self, x, t=None, y=None, **kwargs):
         self.seen.append(None if y is None else (y.dtype, tuple(y.shape)))
-        return self.lin(x)
+        out = self.lin(x)
+        if y is not None:
+            out = out + y.view(-1, 1).float()
+        return out
 
 
 class PlainEnergy(BaseModel):

--- a/tests/test_conditioning.py
+++ b/tests/test_conditioning.py
@@ -61,7 +61,7 @@ class RecordingField(nn.Module):
         self.lin = nn.Linear(dim, dim)
         self.seen = []
 
-    def forward(self, x, t=None, y=None):
+    def forward(self, x, t=None, y=None, **kwargs):
         self.seen.append(None if y is None else (y.dtype, tuple(y.shape)))
         return self.lin(x)
 
@@ -198,7 +198,7 @@ def test_eqm_bare_kwargs_deprecated():
     field = RecordingField()
     loss_fn = EquilibriumMatchingLoss(model=field, energy_type="none")
     with pytest.warns(DeprecationWarning):
-        loss_fn(torch.randn(6, 2), y=_labels(6))
+        loss_fn(torch.randn(6, 2), cond=_labels(6))
 
 
 def test_cd_option_kwargs_deprecated():

--- a/torchebm/core/base_loss.py
+++ b/torchebm/core/base_loss.py
@@ -97,6 +97,7 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
         device: Optional[Union[str, torch.device]] = None,
         cfg_dropout: float = 0.0,
         null_condition: Union[int, float, torch.Tensor, Callable, None] = None,
+        check_conditioning: bool = True,
         *args: Any,
         **kwargs: Any,
     ):
@@ -113,6 +114,12 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
                 ``num_classes`` label convention), a tensor broadcast over the
                 non-batch dims (e.g. a zero embedding), or a callable
                 ``(y, mask) -> y``. Required when ``cfg_dropout > 0``.
+            check_conditioning: If True (default), verify on the first
+                conditional loss call that the model actually consumes ``y``
+                (same input, two distinct in-batch y values; identical outputs
+                raise instead of silently training an unconditional model).
+                Set False for models this probe misjudges, e.g.
+                stochastic-in-eval backbones.
 
         Raises:
             TypeError: If constructor arguments remain that no class in the
@@ -130,6 +137,71 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
         super().__init__(device=device, dtype=dtype)
         self.cfg_dropout = cfg_dropout
         self.null_condition = null_condition
+        self._condition_check_pending = check_conditioning
+
+    def _probe_forward(self, px: torch.Tensor, pmk: dict) -> torch.Tensor:
+        r"""Model call used by the conditioning probe; energy convention."""
+        return self.model(px, **pmk)
+
+    def _check_condition(
+        self, x: torch.Tensor, model_kwargs: Optional[dict]
+    ) -> None:
+        r"""One-time probe that the model consumes ``y`` when it is passed.
+
+        Runs on the first conditional call: the same one-sample input under
+        two distinct in-batch y values (never fabricated labels, which could
+        index outside an embedding), model temporarily in eval mode,
+        gradients off. Identical outputs raise. A first conditional batch
+        with no two distinct y values warns and disarms the probe instead,
+        so no per-step work remains on the hot path.
+
+        Raises:
+            ValueError: If the outputs of the probe pair coincide.
+        """
+        if not self._condition_check_pending or not model_kwargs:
+            return
+        y = model_kwargs.get("y")
+        if y is None:
+            return
+        self._condition_check_pending = False
+        distinct = (y != y[0]).reshape(y.shape[0], -1).any(dim=1)
+        if y.shape[0] < 2 or not bool(distinct.any()):
+            warnings.warn(
+                "Conditioning consumption could not be verified: the first "
+                "conditional batch carries a single distinct y value. Pass "
+                "check_conditioning=False to silence this warning.",
+                UserWarning,
+            )
+            return
+        i1 = int(distinct.int().argmax())
+        px = x[:1].detach()
+        batch = x.shape[0]
+        pmk = {
+            k: v[:1]
+            if isinstance(v, torch.Tensor) and v.ndim > 0 and v.shape[0] == batch
+            else v
+            for k, v in model_kwargs.items()
+            if k != "y"
+        }
+        was_training = self.model.training
+        self.model.eval()
+        try:
+            with torch.no_grad():
+                out_a = self._probe_forward(px, {**pmk, "y": y[0:1]})
+                out_b = self._probe_forward(px, {**pmk, "y": y[i1 : i1 + 1]})
+        finally:
+            self.model.train(was_training)
+        if isinstance(out_a, tuple):
+            out_a = out_a[0]
+        if isinstance(out_b, tuple):
+            out_b = out_b[0]
+        if torch.allclose(out_a, out_b, rtol=1e-5, atol=1e-6):
+            raise ValueError(
+                f"{type(self.model).__name__} returns identical outputs for "
+                "two different y values, so it ignores its conditioning input "
+                "while y was passed. Wire y into the model's forward, or pass "
+                "check_conditioning=False to skip this probe."
+            )
 
     def _apply_cfg_dropout(
         self,

--- a/torchebm/core/base_loss.py
+++ b/torchebm/core/base_loss.py
@@ -109,6 +109,28 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
             raise TypeError(_unexpected_init_args_message(type(self), args, kwargs))
         super().__init__(device=device, dtype=dtype)
 
+    @staticmethod
+    def _merge_condition(
+        model_kwargs: Optional[dict], y: Optional[torch.Tensor]
+    ) -> Optional[dict]:
+        r"""Fold the explicit ``y=`` conditioning into `model_kwargs`.
+
+        ``y=None`` returns `model_kwargs` untouched, keeping the unconditional
+        path identical. Passing ``y`` while `model_kwargs` already carries a
+        ``'y'`` key is ambiguous and raises.
+
+        Raises:
+            ValueError: If both ``y`` and ``model_kwargs['y']`` are given.
+        """
+        if y is None:
+            return model_kwargs
+        if model_kwargs and "y" in model_kwargs:
+            raise ValueError(
+                "y was passed both as y= and inside model_kwargs['y']; "
+                "provide it once"
+            )
+        return {**(model_kwargs or {}), "y": y}
+
     def _resolve_model_kwargs(
         self,
         model_kwargs: Optional[dict],

--- a/torchebm/core/base_loss.py
+++ b/torchebm/core/base_loss.py
@@ -15,7 +15,7 @@ from torchebm.core import BaseSampler
 from torchebm.core import BaseScheduler
 from torchebm.core import Schedulable
 from torchebm.core import TorchEBMModule
-from torchebm.core.base_module import warn_once
+from torchebm.core.base_module import substitute_condition, warn_once
 
 logger = logging.getLogger(__name__)
 
@@ -95,41 +95,69 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
         self,
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
+        cfg_dropout: float = 0.0,
+        null_condition: Union[int, float, torch.Tensor, Callable, None] = None,
         *args: Any,
         **kwargs: Any,
     ):
         """Initialize the base loss class.
 
+        Args:
+            dtype: Data type for computations.
+            device: Device for computations.
+            cfg_dropout: Classifier-free-guidance label dropout: probability of
+                replacing the ``y`` conditioning with `null_condition` per
+                sample during training. 0 (default) disables dropout; applies
+                only in training mode and only when ``y`` is passed.
+            null_condition: Null condition for dropped samples: an int (the
+                ``num_classes`` label convention), a tensor broadcast over the
+                non-batch dims (e.g. a zero embedding), or a callable
+                ``(y, mask) -> y``. Required when ``cfg_dropout > 0``.
+
         Raises:
             TypeError: If constructor arguments remain that no class in the
                 loss's MRO binds; the message lists the supported parameters
                 and the installed torchebm version.
+            ValueError: If ``cfg_dropout`` is outside [0, 1], or positive
+                without a `null_condition`.
         """
         if args or kwargs:
             raise TypeError(_unexpected_init_args_message(type(self), args, kwargs))
+        if not 0.0 <= cfg_dropout <= 1.0:
+            raise ValueError(f"cfg_dropout must be in [0, 1], got {cfg_dropout}")
+        if cfg_dropout > 0 and null_condition is None:
+            raise ValueError("cfg_dropout > 0 requires null_condition")
         super().__init__(device=device, dtype=dtype)
+        self.cfg_dropout = cfg_dropout
+        self.null_condition = null_condition
 
-    @staticmethod
-    def _merge_condition(
-        model_kwargs: Optional[dict], y: Optional[torch.Tensor]
+    def _apply_cfg_dropout(
+        self,
+        model_kwargs: Optional[dict],
+        generator: Optional[torch.Generator] = None,
     ) -> Optional[dict]:
-        r"""Fold the explicit ``y=`` conditioning into `model_kwargs`.
+        r"""Replace ``y`` with the null condition per sample during training.
 
-        ``y=None`` returns `model_kwargs` untouched, keeping the unconditional
-        path identical. Passing ``y`` while `model_kwargs` already carries a
-        ``'y'`` key is ambiguous and raises.
-
-        Raises:
-            ValueError: If both ``y`` and ``model_kwargs['y']`` are given.
+        No-op unless the loss is in training mode, ``cfg_dropout > 0`` and
+        `model_kwargs` carries a ``'y'`` entry. The mask is drawn with
+        `generator` for reproducibility.
         """
-        if y is None:
+        if (
+            self.cfg_dropout == 0.0
+            or not self.training
+            or not model_kwargs
+            or "y" not in model_kwargs
+        ):
             return model_kwargs
-        if model_kwargs and "y" in model_kwargs:
-            raise ValueError(
-                "y was passed both as y= and inside model_kwargs['y']; "
-                "provide it once"
-            )
-        return {**(model_kwargs or {}), "y": y}
+        y = model_kwargs["y"]
+        mask = (
+            torch.rand(y.shape[0], device=y.device, generator=generator)
+            < self.cfg_dropout
+        )
+        return {
+            **model_kwargs,
+            "y": substitute_condition(y, mask, self.null_condition),
+        }
 
     def _resolve_model_kwargs(
         self,

--- a/torchebm/core/base_module.py
+++ b/torchebm/core/base_module.py
@@ -27,6 +27,31 @@ def _normalize(device: torch.device) -> torch.device:
     return device
 
 
+def substitute_condition(y, mask, null):
+    r"""Replace conditioning rows selected by `mask` with the null condition.
+
+    Shared semantics for classifier-free-guidance label dropout (losses) and
+    the guidance wrapper's unconditional half (sampling).
+
+    Args:
+        y: Conditioning tensor of shape (batch_size, ...).
+        mask: Bool tensor of shape (batch_size,); True rows become null.
+        null: Null condition: an int/float filled into y's dtype (the
+            ``num_classes`` label convention), a tensor broadcast over y's
+            non-batch dims (e.g. a zero or learned null embedding), or a
+            callable ``(y, mask) -> y``.
+
+    Returns:
+        Tensor of y's shape with masked rows nulled.
+    """
+    if callable(null):
+        return null(y, mask)
+    mask = mask.view(-1, *([1] * (y.ndim - 1)))
+    if isinstance(null, torch.Tensor):
+        return torch.where(mask, null.to(device=y.device, dtype=y.dtype), y)
+    return torch.where(mask, torch.full_like(y, null), y)
+
+
 _WARNED_ONCE: set = set()
 
 
@@ -71,6 +96,28 @@ class TorchEBMModule(nn.Module):
         self._amp_dtype: torch.dtype = torch.float16
         self._cached_device: Optional[torch.device] = None
         self._cached_dtype: Optional[torch.dtype] = None
+
+    @staticmethod
+    def _merge_condition(
+        model_kwargs: Optional[dict], y: Optional[torch.Tensor]
+    ) -> Optional[dict]:
+        r"""Fold the explicit ``y=`` conditioning into `model_kwargs`.
+
+        ``y=None`` returns `model_kwargs` untouched, keeping the unconditional
+        path identical. Passing ``y`` while `model_kwargs` already carries a
+        ``'y'`` key is ambiguous and raises.
+
+        Raises:
+            ValueError: If both ``y`` and ``model_kwargs['y']`` are given.
+        """
+        if y is None:
+            return model_kwargs
+        if model_kwargs and "y" in model_kwargs:
+            raise ValueError(
+                "y was passed both as y= and inside model_kwargs['y']; "
+                "provide it once"
+            )
+        return {**(model_kwargs or {}), "y": y}
 
     def _resolve_device_dtype(self) -> None:
         try:

--- a/torchebm/losses/contrastive_divergence.py
+++ b/torchebm/losses/contrastive_divergence.py
@@ -115,10 +115,11 @@ class ContrastiveDivergence(BaseContrastiveDivergence):
                 - The scalar CD loss value.
                 - The generated negative samples.
         """
-        model_kwargs = self._apply_cfg_dropout(
-            self._prepare_model_kwargs(self._merge_condition(model_kwargs, y)),
-            generator,
+        model_kwargs = self._prepare_model_kwargs(
+            self._merge_condition(model_kwargs, y)
         )
+        self._check_condition(x, model_kwargs)
+        model_kwargs = self._apply_cfg_dropout(model_kwargs, generator)
         if any(key in kwargs for key in self._CD_OPTION_KEYS):
             warn_once(
                 "cd-option-kwargs",

--- a/torchebm/losses/contrastive_divergence.py
+++ b/torchebm/losses/contrastive_divergence.py
@@ -83,6 +83,7 @@ class ContrastiveDivergence(BaseContrastiveDivergence):
         self,
         x: torch.Tensor,
         *args,
+        y: Optional[torch.Tensor] = None,
         model_kwargs: Optional[dict] = None,
         generator: Optional[torch.Generator] = None,
         **kwargs,
@@ -93,6 +94,9 @@ class ContrastiveDivergence(BaseContrastiveDivergence):
         Args:
             x (torch.Tensor): A batch of real data samples (positive samples).
             *args: Additional positional arguments.
+            y (Optional[torch.Tensor]): Optional conditioning tensor forwarded
+                to the model on both positive and negative paths; shorthand for
+                ``model_kwargs={'y': y}``.
             model_kwargs (Optional[dict]): Conditioning arguments (e.g. class
                 labels) forwarded to the model on both the positive energy calls
                 and the negative-sampling MCMC chains, so the negatives come from
@@ -111,7 +115,7 @@ class ContrastiveDivergence(BaseContrastiveDivergence):
                 - The scalar CD loss value.
                 - The generated negative samples.
         """
-        model_kwargs = self._prepare_model_kwargs(model_kwargs)
+        model_kwargs = self._prepare_model_kwargs(self._merge_condition(model_kwargs, y))
         if any(key in kwargs for key in self._CD_OPTION_KEYS):
             warn_once(
                 "cd-option-kwargs",

--- a/torchebm/losses/contrastive_divergence.py
+++ b/torchebm/losses/contrastive_divergence.py
@@ -115,7 +115,10 @@ class ContrastiveDivergence(BaseContrastiveDivergence):
                 - The scalar CD loss value.
                 - The generated negative samples.
         """
-        model_kwargs = self._prepare_model_kwargs(self._merge_condition(model_kwargs, y))
+        model_kwargs = self._apply_cfg_dropout(
+            self._prepare_model_kwargs(self._merge_condition(model_kwargs, y)),
+            generator,
+        )
         if any(key in kwargs for key in self._CD_OPTION_KEYS):
             warn_once(
                 "cd-option-kwargs",

--- a/torchebm/losses/energy_matching.py
+++ b/torchebm/losses/energy_matching.py
@@ -230,6 +230,7 @@ class EnergyMatchingLoss(BaseLoss):
         self,
         x: torch.Tensor,
         *args,
+        y: Optional[torch.Tensor] = None,
         x0: Optional[torch.Tensor] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
         generator: Optional[torch.Generator] = None,
@@ -240,6 +241,9 @@ class EnergyMatchingLoss(BaseLoss):
         Args:
             x: Data samples of shape (batch_size, ...).
             *args: Additional positional arguments.
+            y: Optional conditioning tensor forwarded to the potential as
+                ``y=``; shorthand for ``model_kwargs={'y': y}``. ``None`` keeps
+                the unconditional path.
             x0: Optional source samples of shape (batch_size, ...). Defaults
                 to standard Gaussian noise; pass a batch from any source
                 distribution for arbitrary source-to-target transport.
@@ -253,6 +257,7 @@ class EnergyMatchingLoss(BaseLoss):
         Returns:
             Scalar loss value.
         """
+        model_kwargs = self._merge_condition(model_kwargs, y)
         if (x.device != self.device) or (x.dtype != self.dtype):
             x = x.to(device=self.device, dtype=self.dtype)
 

--- a/torchebm/losses/energy_matching.py
+++ b/torchebm/losses/energy_matching.py
@@ -286,12 +286,11 @@ class EnergyMatchingLoss(BaseLoss):
         Returns:
             Scalar loss value.
         """
-        mk = self._apply_cfg_dropout(
-            self._resolve_model_kwargs(
-                model_kwargs, kwargs, warn_key="em-bare-model-kwargs"
-            ),
-            generator,
+        mk = self._resolve_model_kwargs(
+            model_kwargs, kwargs, warn_key="em-bare-model-kwargs"
         )
+        self._check_condition(x, mk)
+        mk = self._apply_cfg_dropout(mk, generator)
         terms = self.training_losses(
             x, model_kwargs=mk, x0=x0, generator=generator
         )

--- a/torchebm/losses/energy_matching.py
+++ b/torchebm/losses/energy_matching.py
@@ -286,8 +286,11 @@ class EnergyMatchingLoss(BaseLoss):
         Returns:
             Scalar loss value.
         """
-        mk = self._resolve_model_kwargs(
-            model_kwargs, kwargs, warn_key="em-bare-model-kwargs"
+        mk = self._apply_cfg_dropout(
+            self._resolve_model_kwargs(
+                model_kwargs, kwargs, warn_key="em-bare-model-kwargs"
+            ),
+            generator,
         )
         terms = self.training_losses(
             x, model_kwargs=mk, x0=x0, generator=generator

--- a/torchebm/losses/equilibrium_matching.py
+++ b/torchebm/losses/equilibrium_matching.py
@@ -236,6 +236,11 @@ class EquilibriumMatchingLoss(BaseLoss):
         eps = self.train_eps
         return eps, 1.0 - eps
 
+    def _probe_forward(self, px: torch.Tensor, pmk: dict) -> torch.Tensor:
+        r"""Field convention for the conditioning probe: zeroed time."""
+        t0 = torch.zeros(px.shape[0], device=px.device, dtype=px.dtype)
+        return self.model(px, t0, **pmk)
+
     def _sample_t(
         self, batch: int, generator: Optional[torch.Generator]
     ) -> torch.Tensor:
@@ -385,12 +390,11 @@ class EquilibriumMatchingLoss(BaseLoss):
         Returns:
             Scalar loss value.
         """
-        mk = self._apply_cfg_dropout(
-            self._resolve_model_kwargs(
-                model_kwargs, kwargs, warn_key="eqm-bare-model-kwargs"
-            ),
-            generator,
+        mk = self._resolve_model_kwargs(
+            model_kwargs, kwargs, warn_key="eqm-bare-model-kwargs"
         )
+        self._check_condition(x, mk)
+        mk = self._apply_cfg_dropout(mk, generator)
         terms = self.training_losses(
             x, model_kwargs=mk, x0=x0, generator=generator
         )

--- a/torchebm/losses/equilibrium_matching.py
+++ b/torchebm/losses/equilibrium_matching.py
@@ -57,6 +57,7 @@ class EquilibriumMatchingLoss(BaseLoss):
     with multiple prediction types and loss weighting schemes.
 
     The target is $(\epsilon - x) \cdot c(\gamma)$ where:
+
     - $\epsilon$ is noise (x0), $x$ is data (x1)
     - For linear interpolant: target is $(x_0 - x_1) \cdot c(t)$ (noise - data)
     - $c(\gamma) = \lambda \cdot \min(1, (1-\gamma)/(1-a))$ is truncated decay
@@ -68,10 +69,12 @@ class EquilibriumMatchingLoss(BaseLoss):
         model: Neural network predicting velocity/score/noise.
         prediction: Network prediction type ('velocity', 'score', or 'noise').
         energy_type: Energy formulation type:
+
             - 'none': Implicit EqM, model predicts gradient directly
             - 'dot': $g(x) = x \cdot f(x)$, dot product energy formulation
             - 'l2': $g(x) = -\frac{1}{2}\|f(x)\|^2$ (experimental)
             - 'mean': Same as dot (alias)
+
         interpolant: Interpolant name (e.g. 'linear', 'cosine', 'vp') or BaseInterpolant instance.
         coupling: Minibatch coupling: a name ('independent' (default, identity),
             'ot'/'exact_ot', 'sinkhorn', ...) or a BaseCoupling instance. Pairs
@@ -79,12 +82,14 @@ class EquilibriumMatchingLoss(BaseLoss):
         loss_weight: Loss weighting scheme ('velocity', 'likelihood', or None).
         train_eps: Epsilon for training time interval stability.
         t_sampler: Training-time distribution:
+
             - 'uniform' (default): uniform over the training interval
             - 'lognormal': EDM timestep skew, $\sigma = e^{z p_{std} + p_{mean}}$
               with $z \sim \mathcal{N}(0, 1)$ and $t = 1/(1+\sigma)$ clamped to
               [1e-4, 1] (intersected with the ``train_eps`` interval)
             - a callable ``(batch, *, device, dtype, generator) -> t`` returning
               shape (batch_size,)
+
         t_p_mean: Lognormal skew location $p_{mean}$ (EDM $P_{mean}$). Default: -1.2.
         t_p_std: Lognormal skew scale $p_{std}$ (EDM $P_{std}$), positive. Default: 1.2.
         loss_weight_fn: Optional per-timestep weight hook ``t -> w(t)`` (shape
@@ -94,12 +99,14 @@ class EquilibriumMatchingLoss(BaseLoss):
             unweighted.
         ct: Weight family for the target scaling $c(t)$, always multiplied by
             ``ct_multiplier``:
+
             - 'truncated' (default): $\min(1, (1-t)/(1-a))$, the EqM truncated decay
             - 'linear': $1 - t$, the $a \to 0$ endpoint of the truncated dial
             - 'constant': $1$, the $a \to 1$ endpoint; with ``ct_multiplier=1``
               this is exactly the negated Flow Matching objective
             - a callable ``t -> c(t)`` mapping a (batch_size,) time tensor to
               weights of the same shape
+              
         ct_threshold: Decay threshold $a$ for ct='truncated', strictly inside
             (0, 1); the endpoints are the 'linear' and 'constant' variants.
             Decay starts after $t > a$. Default: 0.8.

--- a/torchebm/losses/equilibrium_matching.py
+++ b/torchebm/losses/equilibrium_matching.py
@@ -378,8 +378,11 @@ class EquilibriumMatchingLoss(BaseLoss):
         Returns:
             Scalar loss value.
         """
-        mk = self._resolve_model_kwargs(
-            model_kwargs, kwargs, warn_key="eqm-bare-model-kwargs"
+        mk = self._apply_cfg_dropout(
+            self._resolve_model_kwargs(
+                model_kwargs, kwargs, warn_key="eqm-bare-model-kwargs"
+            ),
+            generator,
         )
         terms = self.training_losses(
             x, model_kwargs=mk, x0=x0, generator=generator

--- a/torchebm/losses/equilibrium_matching.py
+++ b/torchebm/losses/equilibrium_matching.py
@@ -318,6 +318,7 @@ class EquilibriumMatchingLoss(BaseLoss):
         self,
         x: torch.Tensor,
         *args,
+        y: Optional[torch.Tensor] = None,
         x0: Optional[torch.Tensor] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
         generator: Optional[torch.Generator] = None,
@@ -329,6 +330,9 @@ class EquilibriumMatchingLoss(BaseLoss):
         Args:
             x: Data samples of shape (batch_size, ...).
             *args: Additional positional arguments.
+            y: Optional conditioning tensor (class labels, embeddings, ...)
+                forwarded to the model as ``model(x, t, y=y)``; shorthand for
+                ``model_kwargs={'y': y}``. ``None`` keeps the unconditional path.
             x0: Optional source samples of shape (batch_size, ...). Defaults to
                 standard Gaussian noise; pass a batch from any source
                 distribution for arbitrary source-to-target transport.
@@ -341,6 +345,7 @@ class EquilibriumMatchingLoss(BaseLoss):
         Returns:
             Scalar loss value.
         """
+        model_kwargs = self._merge_condition(model_kwargs, y)
         if (x.device != self.device) or (x.dtype != self.dtype):
             x = x.to(device=self.device, dtype=self.dtype)
 

--- a/torchebm/losses/score_matching.py
+++ b/torchebm/losses/score_matching.py
@@ -140,12 +140,11 @@ class ScoreMatching(BaseScoreMatching):
         Returns:
             torch.Tensor: The scalar score matching loss.
         """
-        mk = self._apply_cfg_dropout(
-            self._resolve_model_kwargs(
-                model_kwargs, kwargs, warn_key="sm-bare-model-kwargs"
-            ),
-            generator,
+        mk = self._resolve_model_kwargs(
+            model_kwargs, kwargs, warn_key="sm-bare-model-kwargs"
         )
+        self._check_condition(x, mk)
+        mk = self._apply_cfg_dropout(mk, generator)
         if self.hessian_method == "approx":
             return self._approx_score_matching(x, model_kwargs=mk, generator=generator)
         else:
@@ -362,12 +361,11 @@ class DenoisingScoreMatching(BaseScoreMatching):
         Returns:
             torch.Tensor: The scalar denoising score matching loss.
         """
-        mk = self._apply_cfg_dropout(
-            self._resolve_model_kwargs(
-                model_kwargs, kwargs, warn_key="dsm-bare-model-kwargs"
-            ),
-            generator,
+        mk = self._resolve_model_kwargs(
+            model_kwargs, kwargs, warn_key="dsm-bare-model-kwargs"
         )
+        self._check_condition(x, mk)
+        mk = self._apply_cfg_dropout(mk, generator)
         x_perturbed, noise = self.perturb_data(x, generator=generator)
 
         score = self.compute_score(x_perturbed, model_kwargs=mk)

--- a/torchebm/losses/score_matching.py
+++ b/torchebm/losses/score_matching.py
@@ -81,6 +81,7 @@ class ScoreMatching(BaseScoreMatching):
         self,
         x: torch.Tensor,
         *args,
+        y: Optional[torch.Tensor] = None,
         model_kwargs: Optional[dict] = None,
         generator: Optional[torch.Generator] = None,
         **kwargs,
@@ -91,6 +92,8 @@ class ScoreMatching(BaseScoreMatching):
         Args:
             x (torch.Tensor): Input data tensor of shape `(batch_size, *data_dims)`.
             *args: Additional positional arguments.
+            y: Optional conditioning tensor; shorthand for
+                ``model_kwargs={'y': y}`` with the same support constraints.
             model_kwargs: Conditioning arguments (e.g. class labels) forwarded to
                 the model. Supported for ``hessian_method="approx"``; the exact
                 Hessian path raises if conditioning is passed (see below).
@@ -99,6 +102,7 @@ class ScoreMatching(BaseScoreMatching):
         Returns:
             torch.Tensor: The scalar score matching loss.
         """
+        model_kwargs = self._merge_condition(model_kwargs, y)
         if (x.device != self.device) or (x.dtype != self.dtype):
             x = x.to(device=self.device, dtype=self.dtype)
 
@@ -298,6 +302,7 @@ class DenoisingScoreMatching(BaseScoreMatching):
         self,
         x: torch.Tensor,
         *args,
+        y: Optional[torch.Tensor] = None,
         model_kwargs: Optional[dict] = None,
         generator: Optional[torch.Generator] = None,
         **kwargs,
@@ -308,6 +313,8 @@ class DenoisingScoreMatching(BaseScoreMatching):
         Args:
             x (torch.Tensor): Input data tensor of shape `(batch_size, *data_dims)`.
             *args: Additional positional arguments.
+            y: Optional conditioning tensor forwarded to the model; shorthand
+                for ``model_kwargs={'y': y}``.
             model_kwargs: Conditioning arguments (e.g. class labels) forwarded to
                 the model. ``None`` (default) is the unconditional path.
             **kwargs: Deprecated bare model kwargs (see `model_kwargs`).
@@ -315,6 +322,7 @@ class DenoisingScoreMatching(BaseScoreMatching):
         Returns:
             torch.Tensor: The scalar denoising score matching loss.
         """
+        model_kwargs = self._merge_condition(model_kwargs, y)
         if (x.device != self.device) or (x.dtype != self.dtype):
             x = x.to(device=self.device, dtype=self.dtype)
 
@@ -466,6 +474,7 @@ class SlicedScoreMatching(BaseScoreMatching):
         self,
         x: torch.Tensor,
         *args,
+        y: Optional[torch.Tensor] = None,
         model_kwargs: Optional[dict] = None,
         generator: Optional[torch.Generator] = None,
         **kwargs,
@@ -476,6 +485,9 @@ class SlicedScoreMatching(BaseScoreMatching):
         Args:
             x (torch.Tensor): Input data tensor of shape `(batch_size, *data_dims)`.
             *args: Additional positional arguments.
+            y: Optional conditioning tensor; conditioning is not supported here,
+                so any non-None value raises in `compute_loss` (see
+                `model_kwargs`).
             model_kwargs: Conditioning is not supported (the projection tiling
                 expands the batch, so per-sample conditioning cannot be aligned);
                 a non-empty mapping raises in `compute_loss`.
@@ -484,6 +496,7 @@ class SlicedScoreMatching(BaseScoreMatching):
         Returns:
             torch.Tensor: The scalar sliced score matching loss.
         """
+        model_kwargs = self._merge_condition(model_kwargs, y)
         if (x.device != self.device) or (x.dtype != self.dtype):
             x = x.to(device=self.device, dtype=self.dtype)
 

--- a/torchebm/losses/score_matching.py
+++ b/torchebm/losses/score_matching.py
@@ -140,8 +140,11 @@ class ScoreMatching(BaseScoreMatching):
         Returns:
             torch.Tensor: The scalar score matching loss.
         """
-        mk = self._resolve_model_kwargs(
-            model_kwargs, kwargs, warn_key="sm-bare-model-kwargs"
+        mk = self._apply_cfg_dropout(
+            self._resolve_model_kwargs(
+                model_kwargs, kwargs, warn_key="sm-bare-model-kwargs"
+            ),
+            generator,
         )
         if self.hessian_method == "approx":
             return self._approx_score_matching(x, model_kwargs=mk, generator=generator)
@@ -359,8 +362,11 @@ class DenoisingScoreMatching(BaseScoreMatching):
         Returns:
             torch.Tensor: The scalar denoising score matching loss.
         """
-        mk = self._resolve_model_kwargs(
-            model_kwargs, kwargs, warn_key="dsm-bare-model-kwargs"
+        mk = self._apply_cfg_dropout(
+            self._resolve_model_kwargs(
+                model_kwargs, kwargs, warn_key="dsm-bare-model-kwargs"
+            ),
+            generator,
         )
         x_perturbed, noise = self.perturb_data(x, generator=generator)
 

--- a/torchebm/models/__init__.py
+++ b/torchebm/models/__init__.py
@@ -11,7 +11,7 @@ This package therefore exposes *reusable building blocks* under
 
 __all__ = [
     "ConditionalTransformer2D",
-    "LabelClassifierFreeGuidance",
+    "ClassifierFreeGuidance",
     "InteractionModel",
     "EqMEnergy",
     "MLPTimestepEmbedder",
@@ -28,7 +28,7 @@ __all__ = [
 
 _LAZY_IMPORTS = {
     "ConditionalTransformer2D": ".conditional_transformer_2d",
-    "LabelClassifierFreeGuidance": ".wrappers",
+    "ClassifierFreeGuidance": ".wrappers",
     "InteractionModel": ".wrappers",
     "EqMEnergy": ".wrappers",
     "AdaLNZeroBlock": ".components",

--- a/torchebm/models/wrappers.py
+++ b/torchebm/models/wrappers.py
@@ -1,58 +1,113 @@
 from __future__ import annotations
 
-from typing import Literal, Optional, Union
+from typing import Callable, Literal, Optional, Union
 
 import torch
 import torch.nn as nn
 
 from torchebm.core import BaseModel, BaseScheduler, Schedulable
+from torchebm.core.base_module import substitute_condition
 
 
-class LabelClassifierFreeGuidance(nn.Module):
-    """Classifier-free guidance wrapper for label-conditioned models.
+class ClassifierFreeGuidance(BaseModel):
+    r"""Classifier-free guidance in one batched forward.
 
-    This wrapper is intentionally small and generic:
-    - assumes the base model accepts `y` (labels) and supports a *null label id*
-    - performs two forward passes (cond and uncond)
-    - applies guidance to the first `guide_channels` channels by default
+    Wraps a conditional model and returns
 
-    It does **not** assume a specific loss (EqM/diffusion/etc).
+    \[
+    \text{out} = u + w \, (c - u)
+    \]
 
-    Expected base signature:
-      `base(x, t, y=..., **kwargs) -> Tensor[B,C,H,W]`
+    where \(c\) and \(u\) are the wrapped model's outputs under the true and
+    null conditioning, evaluated in a single 2x-batch forward (no python
+    loop). Works with field models, called as ``model(x, t, y=y)`` by
+    `FlowSampler`, and with scalar energies, called as ``model(x, y=y)`` and
+    differentiated through the inherited `BaseModel.gradient` by the MCMC and
+    gradient-descent samplers.
 
-    You can use it with `FlowSampler` by wrapping your model instance.
+    \(w = 0\) reproduces the null-conditioned (unconditional) model exactly
+    via a single un-doubled forward; \(w = 1\) matches the conditional model.
+    ``y=None`` is a plain passthrough. Batch-aligned tensors in ``kwargs``
+    are doubled alongside ``x``; a model returning a tuple is unwrapped to
+    its first element.
+
+    Args:
+        model: Conditional model accepting ``y=``.
+        guidance_scale: Guidance weight \(w\).
+        null_condition: Null condition for the unconditional half: an int
+            (the ``num_classes`` label convention), a tensor broadcast over
+            the non-batch dims (e.g. a zero or learned null embedding), or a
+            callable ``(y, mask) -> y``.
+        guide_channels: If set, apply guidance only to the first
+            ``guide_channels`` entries of dim 1 and keep the unconditional
+            output for the rest (models whose extra channels, e.g. a learned
+            sigma, must not be guided). ``None`` (default) guides everything.
     """
 
     def __init__(
         self,
-        base: nn.Module,
-        *,
-        null_label_id: int,
-        cfg_scale: float = 1.0,
-        guide_channels: int = 3,
+        model: nn.Module,
+        guidance_scale: float,
+        null_condition: Union[int, float, torch.Tensor, Callable],
+        guide_channels: Optional[int] = None,
     ):
         super().__init__()
-        self.base = base
-        self.null_label_id = int(null_label_id)
-        self.cfg_scale = float(cfg_scale)
-        self.guide_channels = int(guide_channels)
+        if null_condition is None:
+            raise ValueError("null_condition is required")
+        self.model = model
+        self.guidance_scale = float(guidance_scale)
+        self.null_condition = null_condition
+        self.guide_channels = guide_channels
 
-    def forward(self, x: torch.Tensor, t: torch.Tensor, *, y: torch.Tensor, **kwargs) -> torch.Tensor:
-        if self.cfg_scale <= 1.0:
-            return self.base(x, t, y=y, **kwargs)
+    def _null_y(self, y: torch.Tensor) -> torch.Tensor:
+        mask = torch.ones(y.shape[0], dtype=torch.bool, device=y.device)
+        return substitute_condition(y, mask, self.null_condition)
 
-        y_null = torch.full_like(y, fill_value=self.null_label_id)
+    def _call(self, x, t, y, kwargs):
+        if t is None:
+            out = self.model(x, **kwargs) if y is None else self.model(x, y=y, **kwargs)
+        else:
+            out = (
+                self.model(x, t, **kwargs)
+                if y is None
+                else self.model(x, t, y=y, **kwargs)
+            )
+        return out[0] if isinstance(out, tuple) else out
 
-        cond = self.base(x, t, y=y, **kwargs)
-        uncond = self.base(x, t, y=y_null, **kwargs)
+    def forward(
+        self,
+        x: torch.Tensor,
+        t: Optional[torch.Tensor] = None,
+        y: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if y is None:
+            return self._call(x, t, None, kwargs)
+        w = self.guidance_scale
+        if w == 0.0:
+            return self._call(x, t, self._null_y(y), kwargs)
 
-        c = min(self.guide_channels, cond.shape[1])
-        guided = uncond[:, :c] + self.cfg_scale * (cond[:, :c] - uncond[:, :c])
+        batch = x.shape[0]
 
-        if c == cond.shape[1]:
+        def _double(v):
+            if isinstance(v, torch.Tensor) and v.ndim > 0 and v.shape[0] == batch:
+                return torch.cat([v, v])
+            return v
+
+        out = self._call(
+            torch.cat([x, x]),
+            _double(t),
+            torch.cat([y, self._null_y(y)]),
+            {k: _double(v) for k, v in kwargs.items()},
+        )
+        cond, uncond = out.chunk(2)
+        if self.guide_channels is not None and out.ndim >= 2:
+            c = min(self.guide_channels, cond.shape[1])
+            guided = uncond[:, :c] + w * (cond[:, :c] - uncond[:, :c])
+            if c < cond.shape[1]:
+                guided = torch.cat([guided, uncond[:, c:]], dim=1)
             return guided
-        return torch.cat([guided, uncond[:, c:]], dim=1)
+        return uncond + w * (cond - uncond)
 
 
 class InteractionModel(Schedulable, BaseModel):

--- a/torchebm/samplers/flow.py
+++ b/torchebm/samplers/flow.py
@@ -386,6 +386,7 @@ class FlowSampler(BaseSampler):
         return_diagnostics: bool = False,
         reset_schedulers: bool = True,
         *,
+        y: Optional[torch.Tensor] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
         generator: Optional[torch.Generator] = None,
         **legacy_model_kwargs,
@@ -416,6 +417,8 @@ class FlowSampler(BaseSampler):
                 Fixed-step sampling advances schedulers once per step;
                 adaptive integrators do not step them (the actual step count
                 is controller-dependent).
+            y: Optional conditioning tensor forwarded to the model; shorthand
+                for ``model_kwargs={'y': y}``.
             model_kwargs: Conditioning arguments (e.g. class labels) forwarded to
                 the model at every step. Normalized to the sampler device once at
                 entry; ``None`` (default) is the exact unconditional path.
@@ -454,7 +457,9 @@ class FlowSampler(BaseSampler):
                 "arguments is deprecated; pass model_kwargs={...} instead.",
             )
         model_kwargs = self._prepare_model_kwargs(
-            {**legacy_model_kwargs, **(model_kwargs or {})}
+            self._merge_condition(
+                {**legacy_model_kwargs, **(model_kwargs or {})}, y
+            )
         )
         if thin < 1:
             raise ValueError("thin must be >= 1")

--- a/torchebm/samplers/gradient_descent.py
+++ b/torchebm/samplers/gradient_descent.py
@@ -70,6 +70,7 @@ class GradientDescentSampler(BaseSampler):
         return_diagnostics: bool = False,
         reset_schedulers: bool = True,
         *,
+        y: Optional[torch.Tensor] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
         generator: Optional[torch.Generator] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
@@ -86,6 +87,8 @@ class GradientDescentSampler(BaseSampler):
             return_diagnostics: If True, also return a dict with key
                 ``"energy"`` (`[n_kept]`).
             reset_schedulers: If True (default), reset registered schedulers.
+            y: Optional conditioning tensor forwarded to the model; shorthand
+                for ``model_kwargs={'y': y}``.
             model_kwargs: Conditioning arguments (e.g. class labels) forwarded to
                 the model at every step. Normalized to the sampler device once at
                 entry; ``None`` (default) is the exact unconditional path.
@@ -101,7 +104,9 @@ class GradientDescentSampler(BaseSampler):
             self.reset_schedulers()
 
         x = self._init_state(x, dim, n_samples, generator)
-        model_kwargs = self._prepare_model_kwargs(model_kwargs)
+        model_kwargs = self._prepare_model_kwargs(
+            self._merge_condition(model_kwargs, y)
+        )
 
         n_kept = n_steps // thin
         if return_trajectory:
@@ -204,6 +209,7 @@ class NesterovSampler(BaseSampler):
         return_diagnostics: bool = False,
         reset_schedulers: bool = True,
         *,
+        y: Optional[torch.Tensor] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
         generator: Optional[torch.Generator] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
@@ -220,6 +226,8 @@ class NesterovSampler(BaseSampler):
             return_diagnostics: If True, also return a dict with key
                 ``"energy"`` (`[n_kept]`).
             reset_schedulers: If True (default), reset registered schedulers.
+            y: Optional conditioning tensor forwarded to the model; shorthand
+                for ``model_kwargs={'y': y}``.
             model_kwargs: Conditioning arguments (e.g. class labels) forwarded to
                 the model at every step. Normalized to the sampler device once at
                 entry; ``None`` (default) is the exact unconditional path.
@@ -235,7 +243,9 @@ class NesterovSampler(BaseSampler):
             self.reset_schedulers()
 
         x = self._init_state(x, dim, n_samples, generator)
-        model_kwargs = self._prepare_model_kwargs(model_kwargs)
+        model_kwargs = self._prepare_model_kwargs(
+            self._merge_condition(model_kwargs, y)
+        )
 
         v = torch.zeros_like(x)
         n_kept = n_steps // thin

--- a/torchebm/samplers/hmc.py
+++ b/torchebm/samplers/hmc.py
@@ -170,6 +170,7 @@ class HamiltonianMonteCarlo(BaseSampler):
         return_diagnostics: bool = False,
         reset_schedulers: bool = True,
         *,
+        y: Optional[torch.Tensor] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
         generator: Optional[torch.Generator] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
@@ -187,6 +188,8 @@ class HamiltonianMonteCarlo(BaseSampler):
                 ``"mean"`` (`[n_kept, dim]`), ``"var"`` (`[n_kept, dim]`),
                 ``"energy"`` (`[n_kept]`), and ``"acceptance_rate"`` (`[n_kept]`).
             reset_schedulers: If True (default), reset registered schedulers.
+            y: Optional conditioning tensor forwarded to the model; shorthand
+                for ``model_kwargs={'y': y}``.
             model_kwargs: Conditioning arguments (e.g. class labels) forwarded to
                 the model for both the leapfrog force and the MH-ratio energies.
                 Normalized to the sampler device once at entry; ``None`` (default)
@@ -203,7 +206,9 @@ class HamiltonianMonteCarlo(BaseSampler):
         if reset_schedulers:
             self.reset_schedulers()
 
-        model_kwargs = self._prepare_model_kwargs(model_kwargs)
+        model_kwargs = self._prepare_model_kwargs(
+            self._merge_condition(model_kwargs, y)
+        )
 
         if x is None and dim is None:
             if hasattr(self.model, "mean") and isinstance(
@@ -578,6 +583,7 @@ class RiemannianManifoldHMC(BaseSampler):
         return_diagnostics: bool = False,
         reset_schedulers: bool = True,
         *,
+        y: Optional[torch.Tensor] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
         generator: Optional[torch.Generator] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
@@ -595,6 +601,8 @@ class RiemannianManifoldHMC(BaseSampler):
             return_diagnostics: If True, also return a dict with keys
                 ``"mean"``, ``"var"``, ``"energy"``, and ``"acceptance_rate"``.
             reset_schedulers: If True, reset registered schedulers.
+            y: Optional conditioning tensor forwarded to the model; shorthand
+                for ``model_kwargs={'y': y}``.
             model_kwargs: Conditioning arguments (e.g. class labels) forwarded to
                 the model for both the leapfrog force and the MH-ratio energies.
                 Normalized to the sampler device once at entry; ``None`` (default)
@@ -613,7 +621,9 @@ class RiemannianManifoldHMC(BaseSampler):
 
         # `_force` reads conditioning from this attribute; set it every call so
         # stale conditioning cannot leak in.
-        self._active_model_kwargs = self._prepare_model_kwargs(model_kwargs)
+        self._active_model_kwargs = self._prepare_model_kwargs(
+            self._merge_condition(model_kwargs, y)
+        )
         model_kwargs = self._active_model_kwargs
 
         if x is None and dim is None:

--- a/torchebm/samplers/langevin_dynamics.py
+++ b/torchebm/samplers/langevin_dynamics.py
@@ -91,6 +91,7 @@ class LangevinDynamics(BaseSampler):
         return_diagnostics: bool = False,
         reset_schedulers: bool = True,
         *,
+        y: Optional[torch.Tensor] = None,
         model_kwargs: Optional[Dict[str, Any]] = None,
         generator: Optional[torch.Generator] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, Dict[str, torch.Tensor]]]:
@@ -109,6 +110,8 @@ class LangevinDynamics(BaseSampler):
                 ``"mean"`` (`[n_kept, *data_shape]`), ``"var"``
                 (`[n_kept, *data_shape]`), and ``"energy"`` (`[n_kept]`).
             reset_schedulers: If True (default), reset registered schedulers.
+            y: Optional conditioning tensor forwarded to the model; shorthand
+                for ``model_kwargs={'y': y}``.
             model_kwargs: Conditioning arguments (e.g. class labels) forwarded to
                 the model at every step. Normalized to the sampler device once at
                 entry; ``None`` (default) is the exact unconditional path.
@@ -128,7 +131,9 @@ class LangevinDynamics(BaseSampler):
             self.reset_schedulers()
 
         x = self._init_state(x, dim, n_samples, generator)
-        model_kwargs = self._prepare_model_kwargs(model_kwargs)
+        model_kwargs = self._prepare_model_kwargs(
+            self._merge_condition(model_kwargs, y)
+        )
         n_samples = x.shape[0]
         data_shape = x.shape[1:]
 


### PR DESCRIPTION
Explicit y= conditioning on all loss forwards and sampler sample() methods (shorthand for model_kwargs={'y': ...}; ambiguous double-passing raises). Classifier-free guidance: cfg_dropout label dropout on every loss with a pluggable null condition (int num_classes convention, tensor null embedding, or callable), and a ClassifierFreeGuidance wrapper computing uncond + w*(cond - uncond) in one 2x-batched forward, usable by FlowSampler and every gradient-based sampler; optional guide_channels leaves non-guided output channels (e.g. learned sigma) untouched. A first-conditional-call probe raises if the backbone silently ignores y, with a check_conditioning opt-out.

BREAKING: LabelClassifierFreeGuidance is replaced by ClassifierFreeGuidance (the old wrapper returned the conditional output for cfg_scale <= 1 and used two forward passes). Migration: LabelClassifierFreeGuidance(m, null_label_id=N, cfg_scale=w, guide_channels=c) -> ClassifierFreeGuidance(m, guidance_scale=w, null_condition=N, guide_channels=c).

resolves #260 resolves #261 resolves #262 resolves #263