### PR TITLE
feat(losses): interpolant-loss shared base, flow matching, and model kwargs guard

### DIFF
--- a/docs/concepts/objectives.md
+++ b/docs/concepts/objectives.md
@@ -54,11 +54,28 @@ and sliced SM, which estimates the trace with random projections. DSM at a
 ladder of noise scales is the training principle underlying score-based
 diffusion[^4].
 
-## Transport-based: equilibrium and energy matching
+## Transport-based: flow, equilibrium and energy matching
 
 The modern objectives are simulation-free: they replace the inner sampling
 loop with regression along an interpolant path (see
 [Interpolants and Couplings](transport.md)).
+
+**Flow matching** regresses a time-conditioned velocity field `v(x, t)` onto
+the interpolant velocity `u_t` and generates by integrating it forward with
+`FlowSampler` (no negation). It shares the transport surface of the other
+matching losses: `interpolant=`, `coupling=` with per-pair weights,
+`t_sampler=` (uniform or the EDM lognormal skew), and a per-timestep
+`loss_weight_fn`.
+
+```python
+from torchebm.losses import FlowMatchingLoss
+from torchebm.samplers import FlowSampler
+
+fm = FlowMatchingLoss(model=velocity_net, interpolant="linear")
+# ... train ...
+ode = FlowSampler(velocity_net, interpolant="linear")
+samples = ode.sample(n_samples=64, dim=2, n_steps=50)
+```
 
 **Equilibrium matching** trains a time-invariant field `f(x)` toward the noise
 direction along the path (`f` points data -> noise), so every route transports
@@ -106,6 +123,7 @@ em = EnergyMatchingLoss(model=potential, coupling=SinkhornCoupling(reg=0.01),
 | CD / PCD / PT-CD | yes (k MCMC steps) | energy | MCMC | you need a calibrated energy and can afford MCMC per step |
 | Exact / sliced SM | no (Hessian term) | energy | Langevin | low dimension, no noise tolerance |
 | Denoising SM | no | energy (smoothed) | annealed Langevin | fast sampling-free training, noise scale acceptable |
+| Flow matching | no | velocity field | `FlowSampler` ODE/SDE | pure generative transport, standard diffusion-style recipes |
 | Equilibrium matching | no | field or energy | `FlowSampler` ODE or `EqMEnergy` + gradient descent | generative quality with few integration steps |
 | Energy matching | phase 2 only | energy | one Langevin sweep | one potential for both transport and Boltzmann sampling |
 

--- a/tests/losses/test_base_interpolant_loss.py
+++ b/tests/losses/test_base_interpolant_loss.py
@@ -55,3 +55,72 @@ def test_em_applies_loss_weight_fn():
 def test_em_invalid_t_sampler_raises():
     with pytest.raises(ValueError, match="t_sampler"):
         EnergyMatchingLoss(model=QuadraticPotential(), t_sampler="bogus")
+
+
+def test_em_non_callable_loss_weight_fn_raises():
+    with pytest.raises(TypeError, match="callable or None"):
+        EnergyMatchingLoss(model=QuadraticPotential(), loss_weight_fn=5)
+
+
+def test_em_lognormal_matches_edm_formula():
+    import unittest.mock
+
+    z = torch.tensor([0.0, 1.0, -1.0, 0.5])
+    em = EnergyMatchingLoss(
+        model=QuadraticPotential(), lambda_cd=0.0, t_sampler="lognormal"
+    )
+    with unittest.mock.patch(
+        "torchebm.core.base_loss.torch.randn", return_value=z
+    ):
+        t = em._sample_t(4, generator=None)
+    sigma = torch.exp(z * 1.2 - 1.2)
+    expected = (1.0 / (1.0 + sigma)).clamp(min=1e-4, max=1.0)
+    assert torch.allclose(t, expected, atol=1e-6)
+
+
+def test_em_callable_t_sampler_contract():
+    def sampler(batch, *, device, dtype, generator):
+        assert dtype == torch.float32
+        return torch.full((batch,), 0.3, device=device, dtype=dtype)
+
+    em = EnergyMatchingLoss(
+        model=QuadraticPotential(), lambda_cd=0.0, t_sampler=sampler, device="cpu"
+    )
+    assert torch.allclose(em._sample_t(4, None), torch.full((4,), 0.3))
+
+
+def test_em_lognormal_t_flows_into_weighted_flow_loss():
+    """The drawn lognormal t reaches the flow term, exposed via loss_weight_fn.
+
+    QuadraticPotential gives grad V = xt in closed form, so the flow term is
+    computable by hand: mean over pairs of w(t) * ||-xt - ut||^2 * t.
+    """
+    import unittest.mock
+
+    from torchebm.losses.loss_utils import compute_flow_weight, mean_flat
+    from torchebm.losses.loss_utils import get_interpolant
+
+    batch, dim = 2, 4
+    x1 = torch.randn(batch, dim)
+    x0 = torch.randn(batch, dim)
+    z = torch.tensor([0.3, -0.7])
+
+    em = EnergyMatchingLoss(
+        model=QuadraticPotential(),
+        lambda_cd=0.0,
+        sigma=0.0,
+        coupling="independent",
+        t_sampler="lognormal",
+        loss_weight_fn=lambda t: t,
+        device="cpu",
+    )
+    with unittest.mock.patch(
+        "torchebm.core.base_loss.torch.randn", return_value=z
+    ):
+        loss = em(x1, x0=x0)
+
+    t = (1.0 / (1.0 + torch.exp(z * 1.2 - 1.2))).clamp(min=1e-4, max=1.0)
+    xt, ut = get_interpolant("linear").interpolate(x0, x1, t)
+    w = compute_flow_weight(t, cutoff=em.flow_weight_cutoff)
+    expected = (w * mean_flat((-xt - ut).square()) * t).mean()
+    assert torch.allclose(loss, expected, atol=1e-5)

--- a/tests/losses/test_base_interpolant_loss.py
+++ b/tests/losses/test_base_interpolant_loss.py
@@ -1,0 +1,57 @@
+"""Shared interpolant-loss base: EqM and EnergyMatching sit on one skeleton."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from torchebm.core import BaseModel
+from torchebm.core.base_loss import BaseInterpolantLoss
+from torchebm.losses import EnergyMatchingLoss, EquilibriumMatchingLoss
+
+
+class QuadraticPotential(BaseModel):
+    def forward(self, x, **kwargs):
+        return 0.5 * x.flatten(1).square().sum(dim=1)
+
+
+class LinearField(nn.Module):
+    def __init__(self, dim=4):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim)
+
+    def forward(self, x, t=None, **kwargs):
+        return self.linear(x)
+
+
+def test_both_losses_share_the_base():
+    eqm = EquilibriumMatchingLoss(model=LinearField())
+    em = EnergyMatchingLoss(model=QuadraticPotential(), lambda_cd=0.0)
+    assert isinstance(eqm, BaseInterpolantLoss)
+    assert isinstance(em, BaseInterpolantLoss)
+    assert type(eqm.coupling).__name__ == "IndependentCoupling"
+    assert type(em.coupling).__name__ != "IndependentCoupling"
+
+
+def test_em_accepts_and_dispatches_t_sampler():
+    em = EnergyMatchingLoss(
+        model=QuadraticPotential(), lambda_cd=0.0, t_sampler="lognormal"
+    )
+    t_first = em._sample_t(8, torch.Generator().manual_seed(4))
+    t_second = em._sample_t(8, torch.Generator().manual_seed(4))
+    assert torch.equal(t_first, t_second)
+    assert not torch.all(t_first == t_first[0])
+    assert torch.all((t_first > 0) & (t_first <= 1))
+
+
+def test_em_applies_loss_weight_fn():
+    model = QuadraticPotential()
+    em_weighted = EnergyMatchingLoss(
+        model=model, lambda_cd=0.0, loss_weight_fn=lambda t: torch.zeros_like(t)
+    )
+    loss = em_weighted(torch.randn(8, 4), generator=torch.Generator().manual_seed(2))
+    assert torch.equal(loss, torch.zeros(()))
+
+
+def test_em_invalid_t_sampler_raises():
+    with pytest.raises(ValueError, match="t_sampler"):
+        EnergyMatchingLoss(model=QuadraticPotential(), t_sampler="bogus")

--- a/tests/losses/test_cfg_dropout.py
+++ b/tests/losses/test_cfg_dropout.py
@@ -14,6 +14,7 @@ from torchebm.losses import (
     DenoisingScoreMatching,
     EnergyMatchingLoss,
     EquilibriumMatchingLoss,
+    FlowMatchingLoss,
     ScoreMatching,
 )
 from torchebm.samplers import LangevinDynamics
@@ -69,6 +70,11 @@ LOSSES = [
     ),
     pytest.param(RecordingPotential, DenoisingScoreMatching, id="DenoisingScoreMatching"),
     pytest.param(RecordingPotential, _cd, id="ContrastiveDivergence"),
+    pytest.param(
+        RecordingField,
+        lambda model, **kw: FlowMatchingLoss(model=model, **kw),
+        id="FlowMatchingLoss",
+    ),
 ]
 
 

--- a/tests/losses/test_condition_probe.py
+++ b/tests/losses/test_condition_probe.py
@@ -15,6 +15,7 @@ from torchebm.losses import (
     DenoisingScoreMatching,
     EnergyMatchingLoss,
     EquilibriumMatchingLoss,
+    FlowMatchingLoss,
     ScoreMatching,
 )
 from torchebm.samplers import LangevinDynamics
@@ -72,6 +73,11 @@ LOSSES = [
     ),
     pytest.param(IgnoringPotential, DenoisingScoreMatching, id="DenoisingScoreMatching"),
     pytest.param(IgnoringPotential, _cd, id="ContrastiveDivergence"),
+    pytest.param(
+        IgnoringField,
+        lambda model, **kw: FlowMatchingLoss(model=model, **kw),
+        id="FlowMatchingLoss",
+    ),
 ]
 
 

--- a/tests/losses/test_conditional_y.py
+++ b/tests/losses/test_conditional_y.py
@@ -17,6 +17,7 @@ from torchebm.losses import (
     DenoisingScoreMatching,
     EnergyMatchingLoss,
     EquilibriumMatchingLoss,
+    FlowMatchingLoss,
     ScoreMatching,
     SlicedScoreMatching,
 )
@@ -75,6 +76,11 @@ LOSSES = [
     ),
     pytest.param(RecordingPotential, DenoisingScoreMatching, id="DenoisingScoreMatching"),
     pytest.param(RecordingPotential, _cd, id="ContrastiveDivergence"),
+    pytest.param(
+        RecordingField,
+        lambda model: FlowMatchingLoss(model=model),
+        id="FlowMatchingLoss",
+    ),
 ]
 
 UNSUPPORTED = [

--- a/tests/losses/test_constructor_kwargs.py
+++ b/tests/losses/test_constructor_kwargs.py
@@ -17,6 +17,7 @@ from torchebm.losses import (
     DenoisingScoreMatching,
     EnergyMatchingLoss,
     EquilibriumMatchingLoss,
+    FlowMatchingLoss,
     ScoreMatching,
     SlicedScoreMatching,
 )
@@ -66,6 +67,11 @@ LOSS_FACTORIES = [
         EnergyMatchingLoss,
         lambda **kw: EnergyMatchingLoss(model=QuadraticModel(), **kw),
         id="EnergyMatchingLoss",
+    ),
+    pytest.param(
+        FlowMatchingLoss,
+        lambda **kw: FlowMatchingLoss(model=VelocityModel(), **kw),
+        id="FlowMatchingLoss",
     ),
 ]
 

--- a/tests/losses/test_flow_matching.py
+++ b/tests/losses/test_flow_matching.py
@@ -1,0 +1,139 @@
+"""FlowMatchingLoss: standard conditional flow matching on the shared base."""
+
+import unittest.mock
+
+import pytest
+import torch
+import torch.nn as nn
+
+from torchebm.losses import EquilibriumMatchingLoss, FlowMatchingLoss
+from torchebm.losses.loss_utils import get_interpolant, mean_flat
+
+
+class ConstantField(nn.Module):
+    def __init__(self, out_val=0.5):
+        super().__init__()
+        self.out_val = out_val
+
+    def forward(self, x, t=None, **kwargs):
+        return torch.full_like(x, self.out_val)
+
+
+class LearnableField(nn.Module):
+    def __init__(self, dim=4):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim)
+
+    def forward(self, x, t=None, **kwargs):
+        return self.linear(x)
+
+
+class TimeRecordingField(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.received_time = None
+
+    def forward(self, x, t=None, **kwargs):
+        self.received_time = t
+        return x + t.view(-1, *([1] * (x.ndim - 1)))
+
+
+class Negate(nn.Module):
+    def __init__(self, inner):
+        super().__init__()
+        self.inner = inner
+
+    def forward(self, x, t=None, **kwargs):
+        return -self.inner(x, t, **kwargs)
+
+
+@pytest.mark.parametrize("interpolant", ["linear", "cosine", "vp"])
+def test_fm_loss_finite_scalar(interpolant):
+    loss_fn = FlowMatchingLoss(model=ConstantField(), interpolant=interpolant)
+    loss = loss_fn(torch.randn(16, 4))
+    assert loss.dim() == 0
+    assert torch.isfinite(loss)
+
+
+def test_fm_manual_verification():
+    batch, dim = 2, 4
+    x1 = torch.randn(batch, dim)
+    x0 = torch.randn(batch, dim)
+    t_raw = torch.rand(batch)
+
+    with unittest.mock.patch(
+        "torchebm.core.base_loss.torch.rand", return_value=t_raw
+    ):
+        loss_fn = FlowMatchingLoss(model=ConstantField(0.5), device="cpu")
+        loss = loss_fn(x1, x0=x0)
+
+    _, ut = get_interpolant("linear").interpolate(x0, x1, t_raw)
+    expected = mean_flat((torch.full_like(ut, 0.5) - ut).square()).mean()
+    assert torch.allclose(loss, expected, atol=1e-5)
+
+
+def test_fm_equals_negated_eqm_constant_endpoint():
+    """FM(v) == EqM(-v, ct='constant', ct_multiplier=1): values and gradients.
+
+    EqM conditions the model on zeroed time by construction, so the
+    equivalence holds for time-independent fields.
+    """
+    torch.manual_seed(0)
+    batch, dim = 16, 4
+    v_model = LearnableField(dim=dim)
+    x1 = torch.randn(batch, dim)
+    x0 = torch.randn(batch, dim)
+    t_raw = torch.rand(batch)
+
+    with unittest.mock.patch(
+        "torchebm.core.base_loss.torch.rand", return_value=t_raw
+    ):
+        fm_loss = FlowMatchingLoss(model=v_model, device="cpu")(x1, x0=x0)
+    fm_loss.backward()
+    fm_grads = [p.grad.clone() for p in v_model.parameters()]
+    v_model.zero_grad()
+
+    with unittest.mock.patch(
+        "torchebm.core.base_loss.torch.rand", return_value=t_raw
+    ):
+        eqm_loss = EquilibriumMatchingLoss(
+            model=Negate(v_model), ct="constant", ct_multiplier=1.0, device="cpu"
+        )(x1, x0=x0)
+
+    assert torch.allclose(fm_loss, eqm_loss, atol=1e-6)
+    eqm_loss.backward()
+    for g_fm, p in zip(fm_grads, v_model.parameters()):
+        assert torch.allclose(g_fm, p.grad, atol=1e-6)
+
+
+def test_fm_model_receives_real_time():
+    model = TimeRecordingField()
+    loss_fn = FlowMatchingLoss(model=model)
+    loss_fn(torch.randn(8, 4))
+    assert model.received_time is not None
+    assert not torch.all(model.received_time == 0)
+    assert torch.all((model.received_time >= 0) & (model.received_time <= 1))
+
+
+def test_fm_loss_weight_fn_applies():
+    loss_fn = FlowMatchingLoss(
+        model=ConstantField(), loss_weight_fn=lambda t: torch.zeros_like(t)
+    )
+    assert torch.equal(loss_fn(torch.randn(8, 4)), torch.zeros(()))
+
+
+def test_fm_lognormal_t_sampler_dispatches():
+    loss_fn = FlowMatchingLoss(model=ConstantField(), t_sampler="lognormal")
+    t_first = loss_fn._sample_t(8, torch.Generator().manual_seed(6))
+    t_second = loss_fn._sample_t(8, torch.Generator().manual_seed(6))
+    assert torch.equal(t_first, t_second)
+    assert not torch.all(t_first == t_first[0])
+
+
+def test_fm_samples_through_flow_sampler_without_negation():
+    from torchebm.samplers import FlowSampler
+
+    sampler = FlowSampler(LearnableField(dim=2), integrator="euler")
+    out = sampler.sample(x=torch.randn(4, 2), n_steps=5)
+    assert out.shape == (4, 2)
+    assert torch.isfinite(out).all()

--- a/tests/models/test_constructor_kwargs.py
+++ b/tests/models/test_constructor_kwargs.py
@@ -1,0 +1,95 @@
+"""Unknown model-constructor kwargs must fail with an actionable TypeError.
+
+Mirrors the loss-side guard: without validation, a bogus keyword cascades
+through BaseModel -> TorchEBMModule into nn.Module and dies with a bare
+error naming neither the supported parameters nor the installed version.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from torchebm import __version__
+from torchebm.core import (
+    AckleyModel,
+    DoubleWellModel,
+    GaussianModel,
+    HarmonicModel,
+    RastriginModel,
+    RosenbrockModel,
+)
+from torchebm.models import (
+    ClassifierFreeGuidance,
+    ConditionalTransformer2D,
+    EqMEnergy,
+    InteractionModel,
+)
+
+
+class _Potential(nn.Module):
+    def forward(self, x, **kwargs):
+        return 0.5 * x.square().sum(dim=-1)
+
+
+CASCADING = [
+    pytest.param(DoubleWellModel, lambda **kw: DoubleWellModel(**kw), id="DoubleWellModel"),
+    pytest.param(
+        GaussianModel,
+        lambda **kw: GaussianModel(mean=torch.zeros(2), cov=torch.eye(2), **kw),
+        id="GaussianModel",
+    ),
+    pytest.param(HarmonicModel, lambda **kw: HarmonicModel(**kw), id="HarmonicModel"),
+    pytest.param(RosenbrockModel, lambda **kw: RosenbrockModel(**kw), id="RosenbrockModel"),
+    pytest.param(AckleyModel, lambda **kw: AckleyModel(**kw), id="AckleyModel"),
+    pytest.param(RastriginModel, lambda **kw: RastriginModel(**kw), id="RastriginModel"),
+    pytest.param(
+        InteractionModel,
+        lambda **kw: InteractionModel(_Potential(), sigma_w=4.0, strength=0.1, **kw),
+        id="InteractionModel",
+    ),
+]
+
+FIXED_SIGNATURE = [
+    pytest.param(lambda **kw: EqMEnergy(_Potential(), **kw), id="EqMEnergy"),
+    pytest.param(
+        lambda **kw: ClassifierFreeGuidance(
+            _Potential(), guidance_scale=1.0, null_condition=3, **kw
+        ),
+        id="ClassifierFreeGuidance",
+    ),
+    pytest.param(
+        lambda **kw: ConditionalTransformer2D(
+            in_channels=1,
+            out_channels=1,
+            input_size=4,
+            patch_size=2,
+            embed_dim=8,
+            depth=1,
+            **kw,
+        ),
+        id="ConditionalTransformer2D",
+    ),
+]
+
+
+@pytest.mark.parametrize("cls,factory", CASCADING)
+def test_bogus_kwarg_raises_actionable_typeerror(cls, factory):
+    with pytest.raises(TypeError) as excinfo:
+        factory(bogus_kwarg=123)
+    msg = str(excinfo.value)
+    assert cls.__name__ in msg
+    assert "bogus_kwarg" in msg
+    assert "Supported parameters" in msg
+    assert "device" in msg
+    assert __version__ in msg
+
+
+@pytest.mark.parametrize("factory", FIXED_SIGNATURE)
+def test_fixed_signature_models_reject_bogus_kwarg(factory):
+    with pytest.raises(TypeError):
+        factory(bogus_kwarg=123)
+
+
+def test_device_still_flows_through_cascade():
+    model = DoubleWellModel(barrier_height=1.0, device="cpu", dtype=torch.float32)
+    assert model.device.type == "cpu"

--- a/torchebm/core/base_loss.py
+++ b/torchebm/core/base_loss.py
@@ -282,6 +282,130 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
         return self.__repr__()
 
 
+class BaseInterpolantLoss(BaseLoss):
+    r"""Shared skeleton for interpolant-based losses (EqM, EM, FM).
+
+    Owns the pieces every stochastic-interpolant objective repeats:
+    interpolant and minibatch-coupling resolution, the training-time
+    distribution (`t_sampler`, uniform or the EDM lognormal skew or a
+    callable), the ``train_eps`` interval, and the per-timestep weight hook
+    ``loss_weight_fn``. Subclasses set `_default_coupling` and consume
+    `_sample_t` / `_check_interval` in their forwards; everything else
+    (targets, reductions, regularizers) stays subclass-specific.
+
+    Internal: not exported from ``torchebm.losses``; its constructor
+    signature may change as more losses adopt it.
+
+    Args:
+        interpolant: Interpolant name (e.g. 'linear', 'cosine', 'vp') or
+            BaseInterpolant instance.
+        coupling: Minibatch coupling name or BaseCoupling instance; ``None``
+            uses the subclass default.
+        train_eps: Epsilon for training time interval stability. Float or
+            `BaseScheduler`.
+        t_sampler: Training-time distribution:
+
+            - 'uniform' (default): uniform over the training interval
+            - 'lognormal': EDM timestep skew, $\sigma = e^{z p_{std} + p_{mean}}$
+              with $z \sim \mathcal{N}(0, 1)$ and $t = 1/(1+\sigma)$ clamped to
+              [1e-4, 1] (intersected with the ``train_eps`` interval)
+            - a callable ``(batch, *, device, dtype, generator) -> t``
+              returning shape (batch_size,)
+
+        t_p_mean: Lognormal skew location $p_{mean}$ (EDM $P_{mean}$). Default: -1.2.
+        t_p_std: Lognormal skew scale $p_{std}$ (EDM $P_{std}$), positive. Default: 1.2.
+        loss_weight_fn: Optional per-timestep weight hook ``t -> w(t)`` (shape
+            (batch_size,)) multiplied into the per-sample loss; the mechanism
+            behind min-SNR / EDM $\lambda(\sigma)$ style weightings. None
+            (default) keeps the loss unweighted.
+    """
+
+    _default_coupling = "independent"
+
+    def __init__(
+        self,
+        interpolant="linear",
+        coupling=None,
+        train_eps: Union[float, "BaseScheduler"] = 0.0,
+        t_sampler: Union[str, Callable[..., torch.Tensor]] = "uniform",
+        t_p_mean: float = -1.2,
+        t_p_std: float = 1.2,
+        loss_weight_fn: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ):
+        super().__init__(*args, **kwargs)
+        if not callable(t_sampler) and t_sampler not in ("uniform", "lognormal"):
+            raise ValueError(
+                "t_sampler must be 'uniform', 'lognormal', or a callable "
+                f"(batch, *, device, dtype, generator) -> t, got {t_sampler!r}"
+            )
+        if t_p_std <= 0:
+            raise ValueError(f"t_p_std must be positive, got {t_p_std}")
+        if loss_weight_fn is not None and not callable(loss_weight_fn):
+            raise TypeError(
+                "loss_weight_fn must be callable or None, got "
+                f"{type(loss_weight_fn).__name__}"
+            )
+        self.t_sampler = t_sampler
+        self.t_p_mean = t_p_mean
+        self.t_p_std = t_p_std
+        self.loss_weight_fn = loss_weight_fn
+        self._register_param("train_eps", train_eps)
+        from torchebm.couplings import resolve_coupling
+        from torchebm.interpolants import resolve_interpolant
+
+        owner = type(self).__name__
+        self.interpolant = resolve_interpolant(
+            interpolant, default="linear", owner=owner
+        )
+        self.coupling = resolve_coupling(
+            coupling, default=self._default_coupling, owner=owner
+        )
+
+    @property
+    def train_eps(self) -> float:
+        return self.get_scheduled_value("train_eps")
+
+    @train_eps.setter
+    def train_eps(self, value) -> None:
+        self._register_param("train_eps", value)
+
+    def _check_interval(self) -> Tuple[float, float]:
+        r"""Get training time interval respecting epsilon."""
+        eps = self.train_eps
+        return eps, 1.0 - eps
+
+    def _sample_t(
+        self, batch: int, generator: Optional[torch.Generator]
+    ) -> torch.Tensor:
+        r"""Draw training times for the configured `t_sampler`.
+
+        'lognormal' is the EDM timestep skew: \(\sigma = e^{z p_{std} + p_{mean}}\)
+        with \(z \sim \mathcal{N}(0, 1)\), \(t = 1/(1+\sigma)\), clamped into the
+        training interval with a 1e-4 floor. A callable receives
+        ``(batch, device=, dtype=, generator=)`` and must return shape (batch,).
+        """
+        if callable(self.t_sampler):
+            return self.t_sampler(
+                batch, device=self.device, dtype=self.dtype, generator=generator
+            )
+        t0, t1 = self._check_interval()
+        if self.t_sampler == "lognormal":
+            z = torch.randn(
+                batch, device=self.device, dtype=self.dtype, generator=generator
+            )
+            sigma = torch.exp(z * self.t_p_std + self.t_p_mean)
+            return (1.0 / (1.0 + sigma)).clamp(min=max(1.0e-4, t0), max=t1)
+        return (
+            torch.rand(
+                batch, device=self.device, dtype=self.dtype, generator=generator
+            )
+            * (t1 - t0)
+            + t0
+        )
+
+
 class BaseContrastiveDivergence(BaseLoss):
     r"""
     Abstract base class for Contrastive Divergence (CD) based loss functions.

--- a/torchebm/core/base_loss.py
+++ b/torchebm/core/base_loss.py
@@ -371,6 +371,48 @@ class BaseInterpolantLoss(BaseLoss):
     def train_eps(self, value) -> None:
         self._register_param("train_eps", value)
 
+    def compute_loss(
+        self,
+        x: torch.Tensor,
+        *args,
+        x0: Optional[torch.Tensor] = None,
+        model_kwargs: Optional[Dict[str, Any]] = None,
+        generator: Optional[torch.Generator] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        r"""Resolve conditioning, run `training_losses`, reduce with weights.
+
+        Shared pipeline: model_kwargs resolution (deprecated bare kwargs
+        included), the conditioning-consumption probe, cfg label dropout,
+        then the subclass `training_losses`; per-pair coupling weights, when
+        present, replace the plain mean.
+
+        Args:
+            x: Data samples of shape (batch_size, ...).
+            *args: Additional positional arguments.
+            x0: Optional source samples of shape (batch_size, ...).
+            model_kwargs: Conditioning arguments forwarded to the model.
+            **kwargs: Deprecated bare model kwargs.
+
+        Returns:
+            Scalar loss value.
+        """
+        mk = self._resolve_model_kwargs(
+            model_kwargs,
+            kwargs,
+            warn_key=f"{type(self).__name__}-bare-model-kwargs",
+        )
+        self._check_condition(x, mk)
+        mk = self._apply_cfg_dropout(mk, generator)
+        terms = self.training_losses(
+            x, model_kwargs=mk, x0=x0, generator=generator
+        )
+        loss = terms["loss"]
+        weights = terms.get("weights")
+        if weights is not None:
+            return (weights * loss).sum() / weights.sum().clamp_min(1e-12)
+        return loss.mean()
+
     def _check_interval(self) -> Tuple[float, float]:
         r"""Get training time interval respecting epsilon."""
         eps = self.train_eps

--- a/torchebm/core/base_loss.py
+++ b/torchebm/core/base_loss.py
@@ -15,48 +15,13 @@ from torchebm.core import BaseSampler
 from torchebm.core import BaseScheduler
 from torchebm.core import Schedulable
 from torchebm.core import TorchEBMModule
-from torchebm.core.base_module import substitute_condition, warn_once
+from torchebm.core.base_module import (
+    _unexpected_init_args_message,
+    substitute_condition,
+    warn_once,
+)
 
 logger = logging.getLogger(__name__)
-
-
-def _unexpected_init_args_message(cls, args, kwargs) -> str:
-    r"""Build the TypeError message for constructor arguments no loss accepts.
-
-    Walks `cls.__mro__` down to `BaseLoss` collecting every named constructor
-    parameter, so the message lists what the concrete loss actually supports,
-    including parameters bound by intermediate bases that the leaf signature
-    forwards through ``**kwargs``.
-    """
-    import inspect
-
-    from torchebm._version import __version__
-
-    supported: dict = {}
-    for klass in cls.__mro__:
-        init = klass.__dict__.get("__init__")
-        if init is not None:
-            for name, param in inspect.signature(init).parameters.items():
-                if name != "self" and param.kind not in (
-                    param.VAR_POSITIONAL,
-                    param.VAR_KEYWORD,
-                ):
-                    supported.setdefault(name)
-        if klass is BaseLoss:
-            break
-
-    problems = []
-    if kwargs:
-        problems.append(
-            "unexpected keyword argument(s) "
-            + ", ".join(repr(k) for k in kwargs)
-        )
-    if args:
-        problems.append(f"{len(args)} unexpected positional argument(s)")
-    return (
-        f"{cls.__name__}.__init__() got {' and '.join(problems)}. "
-        f"Supported parameters: {', '.join(supported)} (torchebm {__version__})."
-    )
 
 
 def _dtensor_type():
@@ -129,7 +94,9 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
                 without a `null_condition`.
         """
         if args or kwargs:
-            raise TypeError(_unexpected_init_args_message(type(self), args, kwargs))
+            raise TypeError(
+                _unexpected_init_args_message(type(self), args, kwargs, BaseLoss)
+            )
         if not 0.0 <= cfg_dropout <= 1.0:
             raise ValueError(f"cfg_dropout must be in [0, 1], got {cfg_dropout}")
         if cfg_dropout > 0 and null_condition is None:

--- a/torchebm/core/base_model.py
+++ b/torchebm/core/base_model.py
@@ -5,6 +5,7 @@ from torch import nn
 from typing import Optional, Union
 
 from torchebm.core import TorchEBMModule
+from torchebm.core.base_module import _unexpected_init_args_message
 
 
 class BaseModel(TorchEBMModule, ABC):
@@ -29,11 +30,22 @@ class BaseModel(TorchEBMModule, ABC):
     def __init__(
         self,
         dtype: torch.dtype = torch.float32,
+        device=None,
         *args,
         **kwargs,
     ):
-        """Initializes the BaseModel base class."""
-        super().__init__(dtype=dtype, *args, **kwargs)
+        """Initializes the BaseModel base class.
+
+        Raises:
+            TypeError: If constructor arguments remain that no class in the
+                model's MRO binds; the message lists the supported parameters
+                and the installed torchebm version.
+        """
+        if args or kwargs:
+            raise TypeError(
+                _unexpected_init_args_message(type(self), args, kwargs, BaseModel)
+            )
+        super().__init__(dtype=dtype, device=device)
 
     # @property
     # def device(self) -> torch.device:

--- a/torchebm/core/base_module.py
+++ b/torchebm/core/base_module.py
@@ -27,6 +27,45 @@ def _normalize(device: torch.device) -> torch.device:
     return device
 
 
+def _unexpected_init_args_message(cls, args, kwargs, stop_at: type) -> str:
+    r"""Build the TypeError message for constructor arguments no class accepts.
+
+    Walks `cls.__mro__` down to `stop_at` (inclusive) collecting every named
+    constructor parameter, so the message lists what the concrete class
+    actually supports, including parameters bound by intermediate bases that
+    the leaf signature forwards through ``**kwargs``.
+    """
+    import inspect
+
+    from torchebm._version import __version__
+
+    supported: dict = {}
+    for klass in cls.__mro__:
+        init = klass.__dict__.get("__init__")
+        if init is not None:
+            for name, param in inspect.signature(init).parameters.items():
+                if name != "self" and param.kind not in (
+                    param.VAR_POSITIONAL,
+                    param.VAR_KEYWORD,
+                ):
+                    supported.setdefault(name)
+        if klass is stop_at:
+            break
+
+    problems = []
+    if kwargs:
+        problems.append(
+            "unexpected keyword argument(s) "
+            + ", ".join(repr(k) for k in kwargs)
+        )
+    if args:
+        problems.append(f"{len(args)} unexpected positional argument(s)")
+    return (
+        f"{cls.__name__}.__init__() got {' and '.join(problems)}. "
+        f"Supported parameters: {', '.join(supported)} (torchebm {__version__})."
+    )
+
+
 def substitute_condition(y, mask, null):
     r"""Replace conditioning rows selected by `mask` with the null condition.
 

--- a/torchebm/losses/__init__.py
+++ b/torchebm/losses/__init__.py
@@ -13,6 +13,8 @@ __all__ = [
     "SlicedScoreMatching",
     # Equilibrium Matching
     "EquilibriumMatchingLoss",
+    # Flow Matching
+    "FlowMatchingLoss",
     # Energy Matching
     "EnergyMatchingLoss",
     # Utilities
@@ -32,6 +34,7 @@ _LAZY_IMPORTS = {
     "DenoisingScoreMatching": ".score_matching",
     "SlicedScoreMatching": ".score_matching",
     "EquilibriumMatchingLoss": ".equilibrium_matching",
+    "FlowMatchingLoss": ".flow_matching",
     "EnergyMatchingLoss": ".energy_matching",
     "mean_flat": ".loss_utils",
     "get_interpolant": ".loss_utils",

--- a/torchebm/losses/energy_matching.py
+++ b/torchebm/losses/energy_matching.py
@@ -60,9 +60,7 @@ from torchebm.core import (
     ConstantScheduler,
     TemperatureScheduler,
 )
-from torchebm.core.base_loss import _has_dtensor_params
-from torchebm.couplings import resolve_coupling
-from torchebm.interpolants import resolve_interpolant
+from torchebm.core.base_loss import BaseInterpolantLoss, _has_dtensor_params
 from torchebm.losses.loss_utils import (
     compute_flow_weight,
     mean_flat,
@@ -71,7 +69,7 @@ from torchebm.losses.loss_utils import (
 from torchebm.samplers import LangevinDynamics
 
 
-class EnergyMatchingLoss(BaseLoss):
+class EnergyMatchingLoss(BaseInterpolantLoss):
     r"""Energy Matching (EM) training loss.
 
     Trains a time-independent scalar potential \(V_\theta(x)\) so that
@@ -140,6 +138,8 @@ class EnergyMatchingLoss(BaseLoss):
     pairwise repulsion \(W\)).
     """
 
+    _default_coupling = "ot"
+
     def __init__(
         self,
         model: BaseModel,
@@ -161,7 +161,14 @@ class EnergyMatchingLoss(BaseLoss):
         *args,
         **kwargs,
     ):
-        super().__init__(dtype=dtype, device=device, *args, **kwargs)
+        super().__init__(
+            interpolant=interpolant,
+            coupling=coupling,
+            dtype=dtype,
+            device=device,
+            *args,
+            **kwargs,
+        )
 
         if not 0.0 <= noise_fraction <= 1.0:
             raise ValueError(f"noise_fraction must be in [0, 1], got {noise_fraction}")
@@ -185,12 +192,6 @@ class EnergyMatchingLoss(BaseLoss):
                 dtype=dtype,
                 device=device,
             )
-        )
-        self.coupling = resolve_coupling(
-            coupling, default="ot", owner="EnergyMatchingLoss"
-        )
-        self.interpolant = resolve_interpolant(
-            interpolant, default="linear", owner="EnergyMatchingLoss"
         )
         self._register_param("sigma", sigma)
         self._register_param("lambda_cd", lambda_cd)
@@ -431,9 +432,7 @@ class EnergyMatchingLoss(BaseLoss):
                 )
         coupled = self.coupling(x0, x1, generator=generator, **model_kwargs)
         x0, x1c = coupled
-        t = torch.rand(
-            batch, device=self.device, dtype=self.dtype, generator=generator
-        )
+        t = self._sample_t(batch, generator)
         xt, ut = self.interpolant.interpolate(x0, x1c, t)
 
         sigma = self.sigma
@@ -449,6 +448,8 @@ class EnergyMatchingLoss(BaseLoss):
 
         w = compute_flow_weight(t, cutoff=self.flow_weight_cutoff)
         per_pair = w * mean_flat((-grad - ut).square())
+        if self.loss_weight_fn is not None:
+            per_pair = per_pair * self.loss_weight_fn(t)
         if coupled.weights is not None:
             # Weighted couplings (unbalanced OT) carry per-pair importance
             # weights; uniform weights reduce this exactly to the plain mean.

--- a/torchebm/losses/energy_matching.py
+++ b/torchebm/losses/energy_matching.py
@@ -47,7 +47,7 @@ Key differences from `EquilibriumMatchingLoss` (EqM):
 from __future__ import annotations
 
 import math
-from typing import Any, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 import torch
 
@@ -102,6 +102,21 @@ class EnergyMatchingLoss(BaseInterpolantLoss):
             one-sided trimmed mean.
         cd_clamp: Stability floor: the contrastive term is clamped to
             `>= -cd_clamp`. None disables.
+        t_sampler: Training-time distribution for the flow term:
+
+            - 'uniform' (default): uniform over (0, 1)
+            - 'lognormal': EDM timestep skew, $\sigma = e^{z p_{std} + p_{mean}}$
+              with $z \sim \mathcal{N}(0, 1)$ and $t = 1/(1+\sigma)$ clamped to
+              [1e-4, 1]
+            - a callable ``(batch, *, device, dtype, generator) -> t`` returning
+              shape (batch_size,)
+
+        t_p_mean: Lognormal skew location $p_{mean}$ (EDM $P_{mean}$). Default: -1.2.
+        t_p_std: Lognormal skew scale $p_{std}$ (EDM $P_{std}$), positive. Default: 1.2.
+        loss_weight_fn: Optional per-timestep weight hook ``t -> w(t)`` (shape
+            (batch_size,)) multiplied into the per-pair flow term before
+            reduction; the contrastive term has no timestep and stays
+            unweighted. None (default) keeps the flow term unweighted.
         dtype: Data type for computations.
         device: Device for computations.
 
@@ -156,6 +171,10 @@ class EnergyMatchingLoss(BaseInterpolantLoss):
         noise_fraction: float = 0.5,
         cd_trim_fraction: float = 0.1,
         cd_clamp: Optional[float] = 0.02,
+        t_sampler: Union[str, Callable[..., torch.Tensor]] = "uniform",
+        t_p_mean: float = -1.2,
+        t_p_std: float = 1.2,
+        loss_weight_fn: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
         *args,
@@ -164,6 +183,10 @@ class EnergyMatchingLoss(BaseInterpolantLoss):
         super().__init__(
             interpolant=interpolant,
             coupling=coupling,
+            t_sampler=t_sampler,
+            t_p_mean=t_p_mean,
+            t_p_std=t_p_std,
+            loss_weight_fn=loss_weight_fn,
             dtype=dtype,
             device=device,
             *args,

--- a/torchebm/losses/equilibrium_matching.py
+++ b/torchebm/losses/equilibrium_matching.py
@@ -307,42 +307,6 @@ class EquilibriumMatchingLoss(BaseInterpolantLoss):
 
         return loss
 
-    def compute_loss(
-        self,
-        x: torch.Tensor,
-        *args,
-        x0: Optional[torch.Tensor] = None,
-        model_kwargs: Optional[Dict[str, Any]] = None,
-        generator: Optional[torch.Generator] = None,
-        **kwargs,
-    ) -> torch.Tensor:
-        r"""
-        Compute the equilibrium matching loss.
-
-        Args:
-            x: Data samples of shape (batch_size, ...).
-            *args: Additional positional arguments.
-            x0: Optional source samples (see `forward`).
-            model_kwargs: Conditioning arguments forwarded to the model.
-            **kwargs: Deprecated bare model kwargs (see `forward`).
-
-        Returns:
-            Scalar loss value.
-        """
-        mk = self._resolve_model_kwargs(
-            model_kwargs, kwargs, warn_key="eqm-bare-model-kwargs"
-        )
-        self._check_condition(x, mk)
-        mk = self._apply_cfg_dropout(mk, generator)
-        terms = self.training_losses(
-            x, model_kwargs=mk, x0=x0, generator=generator
-        )
-        loss = terms["loss"]
-        weights = terms.get("weights")
-        if weights is not None:
-            return (weights * loss).sum() / weights.sum().clamp_min(1e-12)
-        return loss.mean()
-
     def training_losses(
         self,
         x1: torch.Tensor,

--- a/torchebm/losses/equilibrium_matching.py
+++ b/torchebm/losses/equilibrium_matching.py
@@ -34,14 +34,11 @@ from torch import nn
 
 from torchebm.core import (
     BaseCoupling,
-    BaseLoss,
     BaseInterpolant,
     BaseScheduler,
     expand_t_like_x,
 )
-from torchebm.core.base_loss import _has_dtensor_params
-from torchebm.couplings import resolve_coupling
-from torchebm.interpolants import resolve_interpolant
+from torchebm.core.base_loss import BaseInterpolantLoss, _has_dtensor_params
 from torchebm.losses import (
     mean_flat,
     compute_eqm_ct,
@@ -49,7 +46,7 @@ from torchebm.losses import (
 )
 
 
-class EquilibriumMatchingLoss(BaseLoss):
+class EquilibriumMatchingLoss(BaseInterpolantLoss):
     r"""Equilibrium Matching (EqM) training loss.
 
     Implements gradient matching for learning equilibrium energy landscapes.
@@ -174,23 +171,18 @@ class EquilibriumMatchingLoss(BaseLoss):
         **kwargs,
     ):
         super().__init__(
+            interpolant=interpolant,
+            coupling=coupling,
+            train_eps=train_eps,
+            t_sampler=t_sampler,
+            t_p_mean=t_p_mean,
+            t_p_std=t_p_std,
+            loss_weight_fn=loss_weight_fn,
             dtype=dtype,
             device=device,
             *args,
             **kwargs,
         )
-        if not callable(t_sampler) and t_sampler not in ("uniform", "lognormal"):
-            raise ValueError(
-                "t_sampler must be 'uniform', 'lognormal', or a callable "
-                f"(batch, *, device, dtype, generator) -> t, got {t_sampler!r}"
-            )
-        if t_p_std <= 0:
-            raise ValueError(f"t_p_std must be positive, got {t_p_std}")
-        if loss_weight_fn is not None and not callable(loss_weight_fn):
-            raise TypeError(
-                "loss_weight_fn must be callable or None, got "
-                f"{type(loss_weight_fn).__name__}"
-            )
         if not callable(ct) and ct not in ("truncated", "linear", "constant"):
             raise ValueError(
                 "ct must be 'truncated', 'linear', 'constant', or a callable "
@@ -206,69 +198,16 @@ class EquilibriumMatchingLoss(BaseLoss):
         self.prediction = prediction
         self.energy_type = energy_type
         self.loss_weight = loss_weight
-        self.t_sampler = t_sampler
-        self.t_p_mean = t_p_mean
-        self.t_p_std = t_p_std
-        self.loss_weight_fn = loss_weight_fn
-        self._register_param("train_eps", train_eps)
         self.ct = ct
         self.ct_threshold = ct_threshold
         self.ct_multiplier = ct_multiplier
         self.apply_dispersion = apply_dispersion
         self.dispersion_weight = dispersion_weight
-        self.interpolant = resolve_interpolant(
-            interpolant, default="linear", owner="EquilibriumMatchingLoss"
-        )
-        self.coupling = resolve_coupling(
-            coupling, default="independent", owner="EquilibriumMatchingLoss"
-        )
-
-    @property
-    def train_eps(self) -> float:
-        return self.get_scheduled_value("train_eps")
-
-    @train_eps.setter
-    def train_eps(self, value: Union[float, BaseScheduler]) -> None:
-        self._register_param("train_eps", value)
-
-    def _check_interval(self) -> tuple[float, float]:
-        r"""Get training time interval respecting epsilon."""
-        eps = self.train_eps
-        return eps, 1.0 - eps
 
     def _probe_forward(self, px: torch.Tensor, pmk: dict) -> torch.Tensor:
         r"""Field convention for the conditioning probe: zeroed time."""
         t0 = torch.zeros(px.shape[0], device=px.device, dtype=px.dtype)
         return self.model(px, t0, **pmk)
-
-    def _sample_t(
-        self, batch: int, generator: Optional[torch.Generator]
-    ) -> torch.Tensor:
-        r"""Draw training times for the configured `t_sampler`.
-
-        'lognormal' is the EDM timestep skew: \(\sigma = e^{z p_{std} + p_{mean}}\)
-        with \(z \sim \mathcal{N}(0, 1)\), \(t = 1/(1+\sigma)\), clamped into the
-        training interval with a 1e-4 floor. A callable receives
-        ``(batch, device=, dtype=, generator=)`` and must return shape (batch,).
-        """
-        if callable(self.t_sampler):
-            return self.t_sampler(
-                batch, device=self.device, dtype=self.dtype, generator=generator
-            )
-        t0, t1 = self._check_interval()
-        if self.t_sampler == "lognormal":
-            z = torch.randn(
-                batch, device=self.device, dtype=self.dtype, generator=generator
-            )
-            sigma = torch.exp(z * self.t_p_std + self.t_p_mean)
-            return (1.0 / (1.0 + sigma)).clamp(min=max(1.0e-4, t0), max=t1)
-        return (
-            torch.rand(
-                batch, device=self.device, dtype=self.dtype, generator=generator
-            )
-            * (t1 - t0)
-            + t0
-        )
 
     def _compute_ct(self, t: torch.Tensor) -> torch.Tensor:
         r"""Target scaling c(t) for the configured variant, times `ct_multiplier`."""

--- a/torchebm/losses/flow_matching.py
+++ b/torchebm/losses/flow_matching.py
@@ -1,0 +1,205 @@
+r"""Flow Matching (FM) loss.
+
+Standard conditional flow matching: regress a time-conditioned velocity field
+onto the interpolant velocity,
+
+\[
+L_{FM} = \|v_\theta(x_t, t) - u_t\|^2, \qquad
+x_t, u_t = \mathrm{interpolant}(x_0, x_1, t)
+\]
+
+with \(x_0\) noise (or any source batch) and \(x_1\) data. Sampling integrates
+the learned velocity forward with `FlowSampler` (no ``negate_velocity``).
+
+Relation to Equilibrium Matching: with ``ct="constant"`` and
+``ct_multiplier=1`` the EqM objective is exactly this loss with the field
+negated and the time conditioning zeroed.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Literal, Optional, Union
+
+import torch
+from torch import nn
+
+from torchebm.core import BaseCoupling, BaseInterpolant, BaseScheduler
+from torchebm.core.base_loss import BaseInterpolantLoss
+from torchebm.losses import mean_flat
+
+
+class FlowMatchingLoss(BaseInterpolantLoss):
+    r"""Conditional Flow Matching training loss.
+
+    Trains ``model(x_t, t, **model_kwargs)`` to predict the interpolant
+    velocity \(u_t\). The model receives the true training time (unlike
+    `EquilibriumMatchingLoss`, whose field is time-invariant).
+
+    Args:
+        model: Neural network predicting velocity, called as ``model(x, t)``.
+        interpolant: Interpolant name (e.g. 'linear', 'cosine', 'vp') or
+            BaseInterpolant instance.
+        coupling: Minibatch coupling: a name ('independent' (default,
+            identity), 'ot'/'exact_ot', 'sinkhorn', ...) or a BaseCoupling
+            instance. Pairs the source and target batches before
+            interpolation; per-pair weights are honored in the reduction.
+        train_eps: Epsilon for training time interval stability.
+        t_sampler: Training-time distribution: 'uniform' (default),
+            'lognormal' (EDM timestep skew), or a callable
+            ``(batch, *, device, dtype, generator) -> t``.
+        t_p_mean: Lognormal skew location $p_{mean}$. Default: -1.2.
+        t_p_std: Lognormal skew scale $p_{std}$, positive. Default: 1.2.
+        loss_weight_fn: Optional per-timestep weight hook ``t -> w(t)``
+            multiplied into the per-sample loss.
+        dtype: Data type for computations.
+        device: Device for computations.
+
+    Example:
+        ```python
+        from torchebm.losses import FlowMatchingLoss
+        from torchebm.samplers import FlowSampler
+
+        loss_fn = FlowMatchingLoss(model=velocity_net, interpolant="linear")
+        loss = loss_fn(x_batch)
+        # ... train, then:
+        sampler = FlowSampler(velocity_net, interpolant="linear")
+        samples = sampler.sample(n_samples=64, dim=2, n_steps=50)
+        ```
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        interpolant: Union[str, BaseInterpolant] = "linear",
+        coupling: Union[str, BaseCoupling, None] = None,
+        train_eps: Union[float, BaseScheduler] = 0.0,
+        t_sampler: Union[
+            Literal["uniform", "lognormal"],
+            Callable[..., torch.Tensor],
+        ] = "uniform",
+        t_p_mean: float = -1.2,
+        t_p_std: float = 1.2,
+        loss_weight_fn: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
+        dtype: torch.dtype = torch.float32,
+        device: Optional[Union[str, torch.device]] = None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(
+            interpolant=interpolant,
+            coupling=coupling,
+            train_eps=train_eps,
+            t_sampler=t_sampler,
+            t_p_mean=t_p_mean,
+            t_p_std=t_p_std,
+            loss_weight_fn=loss_weight_fn,
+            dtype=dtype,
+            device=device,
+            *args,
+            **kwargs,
+        )
+        self.model = model
+
+    def _probe_forward(self, px: torch.Tensor, pmk: dict) -> torch.Tensor:
+        r"""Field convention for the conditioning probe: fixed mid-path time."""
+        t = torch.full((px.shape[0],), 0.5, device=px.device, dtype=px.dtype)
+        return self.model(px, t, **pmk)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        *args,
+        y: Optional[torch.Tensor] = None,
+        x0: Optional[torch.Tensor] = None,
+        model_kwargs: Optional[Dict[str, Any]] = None,
+        generator: Optional[torch.Generator] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        r"""Compute the FM loss (nn.Module interface).
+
+        Args:
+            x: Data samples of shape (batch_size, ...).
+            *args: Additional positional arguments.
+            y: Optional conditioning tensor forwarded to the model; shorthand
+                for ``model_kwargs={'y': y}``.
+            x0: Optional source samples of shape (batch_size, ...). Defaults to
+                standard Gaussian noise.
+            model_kwargs: Conditioning arguments forwarded to the model.
+            **kwargs: Deprecated bare model kwargs; pass ``model_kwargs={...}``.
+
+        Returns:
+            Scalar loss value.
+        """
+        model_kwargs = self._merge_condition(model_kwargs, y)
+        if (x.device != self.device) or (x.dtype != self.dtype):
+            x = x.to(device=self.device, dtype=self.dtype)
+
+        with self.autocast_context():
+            loss = self.compute_loss(
+                x, *args, x0=x0, model_kwargs=model_kwargs, generator=generator, **kwargs
+            )
+        return loss
+
+    def training_losses(
+        self,
+        x1: torch.Tensor,
+        model_kwargs: Optional[Dict[str, Any]] = None,
+        x0: Optional[torch.Tensor] = None,
+        generator: Optional[torch.Generator] = None,
+    ) -> Dict[str, torch.Tensor]:
+        r"""Compute training losses with detailed outputs.
+
+        Args:
+            x1: Data samples of shape (batch_size, ...).
+            model_kwargs: Conditioning forwarded to the model.
+            x0: Optional source samples; standard Gaussian noise when None.
+                Paired against ``x1`` by the configured coupling.
+            generator: RNG for the source draw, the coupling and the time
+                sampling; the global RNG when ``None``.
+
+        Returns:
+            Dictionary with 'loss' (per-sample), 'pred', and 'weights'
+            (per-pair coupling weights or None).
+        """
+        if model_kwargs is None:
+            model_kwargs = {}
+
+        x1 = x1.to(device=self.device, dtype=self.dtype)
+        batch = x1.shape[0]
+
+        if x0 is None:
+            x0 = torch.randn_like(x1, generator=generator)
+        else:
+            x0 = x0.to(device=self.device, dtype=self.dtype)
+            if x0.shape != x1.shape:
+                raise ValueError(
+                    f"x0 shape {tuple(x0.shape)} must match x1 shape {tuple(x1.shape)}"
+                )
+
+        coupled = self.coupling(x0, x1, generator=generator, **model_kwargs)
+        x0, x1 = coupled
+
+        t = self._sample_t(batch, generator)
+        xt, ut = self.interpolant.interpolate(x0, x1, t)
+
+        with self.autocast_context():
+            pred = self.model(xt, t, **model_kwargs)
+        if isinstance(pred, tuple):
+            pred = pred[0]
+
+        loss = mean_flat((pred - ut).square())
+        if self.loss_weight_fn is not None:
+            loss = loss * self.loss_weight_fn(t)
+
+        return {"loss": loss, "pred": pred, "weights": coupled.weights}
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"interpolant={type(self.interpolant).__name__}, "
+            f"coupling={type(self.coupling).__name__}, "
+            f"t_sampler={self.t_sampler!r})"
+        )
+
+
+__all__ = ["FlowMatchingLoss"]


### PR DESCRIPTION
Extracts an internal BaseInterpolantLoss owning the shared interpolant-loss skeleton (interpolant/coupling resolution, train_eps interval, t_sampler with the EDM lognormal skew, per-timestep loss_weight_fn, and the conditioning pipeline), with EquilibriumMatchingLoss and EnergyMatchingLoss on top; EnergyMatching gains t_sampler and loss_weight_fn. Adds FlowMatchingLoss, the standard conditional flow matching objective, pinned by a value-and-gradient equivalence test against EquilibriumMatchingLoss(ct='constant', ct_multiplier=1) and covered by every cross-loss capability suite. BaseModel constructors now reject unknown kwargs with a TypeError listing the supported parameters and installed version, matching the loss-side behavior.

resolves #265 resolves #266 resolves #267 resolves #268 resolves #269