### PR TITLE
ci(release): use changelog section as github release body

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -124,13 +124,31 @@ jobs:
         password: ${{ secrets.PYPI_API_TOKEN_EBM }}
         verbose: true
 
+    # The release body is the tag's own CHANGELOG.md section (commit-level
+    # detail); GitHub's generated notes (PR list + Full Changelog link) are
+    # appended below it. An empty extract (version mismatch) falls back to
+    # the generated notes alone.
+    - name: Extract release notes from CHANGELOG.md
+      env:
+        RELEASE_TAG: ${{ needs.update-tag.outputs.new_tag }}
+      run: |
+        awk -v ver="${RELEASE_TAG#v}" '
+          $0 ~ ("^## \\[" ver "\\]") {found=1; next}
+          /^## \[/ {found=0}
+          found
+        ' CHANGELOG.md > release_body.md
+
     - name: Create GitHub Release
       uses: actions/github-script@v7
       env:
         RELEASE_TAG: ${{ needs.update-tag.outputs.new_tag }}
       with:
         script: |
+          const fs = require('fs');
+          let body = '';
+          try { body = fs.readFileSync('release_body.md', 'utf8').trim(); } catch {}
           const response = await github.rest.repos.createRelease({
+            body: body,
             draft: false,
             generate_release_notes: true,
             name: process.env.RELEASE_TAG,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-09-01
+
+### Other
+
+- [`f3c9672`](https://github.com/soran-ghaderi/torchebm/commit/f3c9672d6cbbe84b5476975144e997408cc7a187) - use changelog section as github release body
+
 ## [0.8.3] - 2026-09-01
 
 ### Other


### PR DESCRIPTION
GitHub Releases created since v0.6.0 only carry the auto-generated PR list, one line per release under the one-PR-per-release flow. The release job now extracts the minted tag's section from CHANGELOG.md as the release body, with the generated notes appended; an empty extract falls back to generated notes alone.