### PR TITLE
feat(losses): model_time on equilibrium matching and negate_velocity on flow matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to ∇ TorchEBM will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.6](https://github.com/soran-ghaderi/torchebm/compare/v0.8.5...v0.8.6) - 2026-09-02
+
+### Added
+
+- [`0f06ff9`](https://github.com/soran-ghaderi/torchebm/commit/0f06ff97d8c554792a72d4e340be9001904dde62) - model_time option for the clock shown to the eqm model (#283)
+- [`f2eb083`](https://github.com/soran-ghaderi/torchebm/commit/f2eb08362d35aec56503cde29e52b1170a814a05) - negate_velocity option on flow matching for descent samplers (#284)
+
+### Other
+
+- [`f6eb062`](https://github.com/soran-ghaderi/torchebm/commit/f6eb062bb74cb9918eec10a81a5328bc26b9506b) - stamp since to the 0.8.5 release that shipped the warnings
+
 ## [0.8.5](https://github.com/soran-ghaderi/torchebm/compare/v0.8.4...v0.8.5) - 2026-09-01
 
 ### Added

--- a/docs/concepts/objectives.md
+++ b/docs/concepts/objectives.md
@@ -103,6 +103,22 @@ gd = GradientDescentSampler(EqMEnergy.from_loss(eqm))                 # descend 
 (implicit vs dot/l2), so the sampled energy always matches what was trained.
 `InteractionModel` must wrap an explicit energy, never the implicit adapter.
 
+The two losses differ only in the sign of the regression target and in the
+clock the model sees; each has a switch to adopt the other's convention:
+
+| Loss | Target | Clock shown to the model | Sample with |
+| --- | --- | --- | --- |
+| `FlowMatchingLoss` | `u_t` (noise -> data) | sampled `t` | `FlowSampler` |
+| `FlowMatchingLoss(negate_velocity=True)` | `-u_t` (data -> noise) | sampled `t` | `FlowSampler(negate_velocity=True)`, descent samplers via `EqMEnergy` |
+| `EquilibriumMatchingLoss` | `-u_t * c(t)` | zeros (`model_time="zero"`) | `FlowSampler(negate_velocity=True)`, `EqMEnergy` |
+| `EquilibriumMatchingLoss(model_time="true")` | `-u_t * c(t)` | sampled `t` | `FlowSampler(negate_velocity=True)` |
+
+`model_time` also accepts a callable `t -> t'` for clock schedules and
+reparametrisations; apply the same map at sampling time. With `ct="constant"`,
+`ct_multiplier=1` and `model_time="true"` the EqM objective is bit-identical to
+`FlowMatchingLoss(negate_velocity=True)`. `EqMEnergy` always evaluates the
+field at `t = 0`, so it suits time-invariant fields.
+
 **Energy matching** (arXiv:2504.10612) keeps a single time-independent scalar
 potential: an OT flow-matching warm-up shapes it as transport, then a
 contrastive phase with temperature-scheduled Langevin negatives sharpens its

--- a/tests/losses/test_equilibrium_matching.py
+++ b/tests/losses/test_equilibrium_matching.py
@@ -766,6 +766,79 @@ def test_loss_weight_fn_non_callable_raises():
         EquilibriumMatchingLoss(model=DummyModel(), loss_weight_fn=5)
 
 
+# model_time: the clock shown to the model
+# ========================================
+
+
+class TimeConditionedModel(nn.Module):
+    def forward(self, x, t=None, **kwargs):
+        return x + t.view(-1, *([1] * (x.ndim - 1)))
+
+
+def _fixed_t(t):
+    return lambda batch, *, device, dtype, generator: t.to(device=device, dtype=dtype)
+
+
+def test_model_time_default_zeroes_clock():
+    model = DummyModel()
+    EquilibriumMatchingLoss(model=model)(torch.randn(8, 4))
+    assert model.last_t.shape == (8,)
+    assert torch.equal(model.last_t, torch.zeros(8))
+
+
+def test_model_time_true_passes_sampled_t():
+    t = torch.rand(8)
+    model = DummyModel()
+    EquilibriumMatchingLoss(model=model, model_time="true", t_sampler=_fixed_t(t))(
+        torch.randn(8, 4)
+    )
+    assert torch.equal(model.last_t, t)
+
+
+def test_model_time_callable_maps_clock_elementwise():
+    t = torch.rand(8)
+    model = DummyModel()
+    EquilibriumMatchingLoss(
+        model=model, model_time=lambda t: 1.0 - t, t_sampler=_fixed_t(t)
+    )(torch.randn(8, 4))
+    assert torch.equal(model.last_t, 1.0 - t)
+
+
+def test_model_time_applies_to_conditioning_probe():
+    model = DummyModel()
+    loss_fn = EquilibriumMatchingLoss(model=model, model_time=lambda t: t + 0.25)
+    loss_fn._probe_forward(torch.randn(4, 2), {})
+    assert torch.equal(model.last_t, torch.full((4,), 0.25))
+
+
+def test_model_time_changes_loss_only_for_time_conditioned_model():
+    t = torch.rand(16)
+    x1, x0 = torch.randn(16, 4), torch.randn(16, 4)
+
+    def loss(model, model_time):
+        return EquilibriumMatchingLoss(
+            model=model, model_time=model_time, t_sampler=_fixed_t(t)
+        )(x1, x0=x0)
+
+    conditioned = TimeConditionedModel()
+    assert not torch.equal(loss(conditioned, "zero"), loss(conditioned, "true"))
+    torch.manual_seed(0)
+    invariant = LearnableModel(4)
+    assert torch.equal(loss(invariant, "zero"), loss(invariant, "true"))
+
+
+def test_model_time_invalid_raises():
+    with pytest.raises(ValueError, match="model_time must be"):
+        EquilibriumMatchingLoss(model=DummyModel(), model_time="sampled")
+
+
+def test_model_time_in_repr():
+    assert "model_time='zero'" in repr(EquilibriumMatchingLoss(model=DummyModel()))
+    assert "model_time='true'" in repr(
+        EquilibriumMatchingLoss(model=DummyModel(), model_time="true")
+    )
+
+
 # Fixture for device testing
 @pytest.fixture(params=["cpu", "cuda"])
 def device(request):

--- a/tests/losses/test_flow_matching.py
+++ b/tests/losses/test_flow_matching.py
@@ -47,6 +47,19 @@ class Negate(nn.Module):
         return -self.inner(x, t, **kwargs)
 
 
+class LearnableTimeField(nn.Module):
+    def __init__(self, dim=4):
+        super().__init__()
+        self.linear = nn.Linear(dim + 1, dim)
+
+    def forward(self, x, t=None, **kwargs):
+        return self.linear(torch.cat([x, t.unsqueeze(-1)], dim=-1))
+
+
+def _fixed_t(t):
+    return lambda batch, *, device, dtype, generator: t.to(device=device, dtype=dtype)
+
+
 @pytest.mark.parametrize("interpolant", ["linear", "cosine", "vp"])
 def test_fm_loss_finite_scalar(interpolant):
     loss_fn = FlowMatchingLoss(model=ConstantField(), interpolant=interpolant)
@@ -104,6 +117,101 @@ def test_fm_equals_negated_eqm_constant_endpoint():
     eqm_loss.backward()
     for g_fm, p in zip(fm_grads, v_model.parameters()):
         assert torch.allclose(g_fm, p.grad, atol=1e-6)
+
+
+def test_fm_equals_negated_eqm_true_clock_for_time_conditioned_field():
+    """FM(v) == EqM(-v, ct='constant', ct_multiplier=1, model_time='true')."""
+    torch.manual_seed(0)
+    batch, dim = 16, 4
+    v_model = LearnableTimeField(dim=dim)
+    x1, x0, t = torch.randn(batch, dim), torch.randn(batch, dim), torch.rand(batch)
+
+    fm_loss = FlowMatchingLoss(model=v_model, t_sampler=_fixed_t(t))(x1, x0=x0)
+    eqm_loss = EquilibriumMatchingLoss(
+        model=Negate(v_model),
+        ct="constant",
+        ct_multiplier=1.0,
+        model_time="true",
+        t_sampler=_fixed_t(t),
+    )(x1, x0=x0)
+    assert torch.allclose(fm_loss, eqm_loss, atol=1e-6)
+
+    zeroed = EquilibriumMatchingLoss(
+        model=Negate(v_model), ct="constant", ct_multiplier=1.0, t_sampler=_fixed_t(t)
+    )(x1, x0=x0)
+    assert not torch.allclose(fm_loss, zeroed, atol=1e-6)
+
+
+# negate_velocity
+# ===============
+
+
+def test_fm_negate_velocity_target():
+    batch, dim = 4, 3
+    x1, x0, t = torch.randn(batch, dim), torch.randn(batch, dim), torch.rand(batch)
+    loss = FlowMatchingLoss(
+        model=ConstantField(0.5), negate_velocity=True, t_sampler=_fixed_t(t)
+    )(x1, x0=x0)
+    _, ut = get_interpolant("linear").interpolate(x0, x1, t)
+    expected = mean_flat((torch.full_like(ut, 0.5) + ut).square()).mean()
+    assert torch.allclose(loss, expected, atol=1e-6)
+
+
+def test_fm_negate_velocity_false_is_default_path():
+    batch, dim = 8, 4
+    x1, x0, t = torch.randn(batch, dim), torch.randn(batch, dim), torch.rand(batch)
+    model = ConstantField(0.5)
+    default = FlowMatchingLoss(model=model, t_sampler=_fixed_t(t))(x1, x0=x0)
+    explicit = FlowMatchingLoss(
+        model=model, negate_velocity=False, t_sampler=_fixed_t(t)
+    )(x1, x0=x0)
+    assert torch.equal(default, explicit)
+
+
+def test_fm_negated_is_bitwise_eqm_constant_true_clock():
+    """FM(negate_velocity=True) == EqM(ct='constant', ct_multiplier=1, model_time='true')."""
+    torch.manual_seed(0)
+    batch, dim = 16, 4
+    model = LearnableTimeField(dim=dim)
+    x1, x0, t = torch.randn(batch, dim), torch.randn(batch, dim), torch.rand(batch)
+
+    fm_loss = FlowMatchingLoss(
+        model=model, negate_velocity=True, t_sampler=_fixed_t(t)
+    )(x1, x0=x0)
+    fm_loss.backward()
+    fm_grads = [p.grad.clone() for p in model.parameters()]
+    model.zero_grad()
+
+    eqm_loss = EquilibriumMatchingLoss(
+        model=model,
+        ct="constant",
+        ct_multiplier=1.0,
+        model_time="true",
+        t_sampler=_fixed_t(t),
+    )(x1, x0=x0)
+    assert torch.equal(fm_loss, eqm_loss)
+    eqm_loss.backward()
+    for g_fm, p in zip(fm_grads, model.parameters()):
+        assert torch.equal(g_fm, p.grad)
+
+
+def test_fm_negated_field_descends_through_eqm_energy():
+    from torchebm.models import EqMEnergy
+    from torchebm.samplers import GradientDescentSampler
+
+    field = LearnableField(dim=2)
+    FlowMatchingLoss(model=field, negate_velocity=True)(torch.randn(8, 2)).backward()
+    sampler = GradientDescentSampler(EqMEnergy(field, energy_type="implicit"), step_size=0.1)
+    out = sampler.sample(x=torch.randn(4, 2), n_steps=5)
+    assert out.shape == (4, 2)
+    assert torch.isfinite(out).all()
+
+
+def test_fm_negate_velocity_in_repr():
+    assert "negate_velocity=False" in repr(FlowMatchingLoss(model=ConstantField()))
+    assert "negate_velocity=True" in repr(
+        FlowMatchingLoss(model=ConstantField(), negate_velocity=True)
+    )
 
 
 def test_fm_model_receives_real_time():

--- a/torchebm/core/base_loss.py
+++ b/torchebm/core/base_loss.py
@@ -26,7 +26,7 @@ from torchebm.core.base_module import (
 _BARE_MODEL_KWARGS_DEPRECATION = declare_deprecation(
     module=__name__,
     name="bare model-conditioning kwargs",
-    since="0.8.4",
+    since="0.8.5",
     deprecated_on="2026-08-31",
     replacement="model_kwargs={...}",
     message=(

--- a/torchebm/losses/contrastive_divergence.py
+++ b/torchebm/losses/contrastive_divergence.py
@@ -14,7 +14,7 @@ from torchebm._deprecation import declare_deprecation
 _CD_OPTION_KWARGS_DEPRECATION = declare_deprecation(
     module=__name__,
     name="ContrastiveDivergence loss-option call kwargs",
-    since="0.8.4",
+    since="0.8.5",
     deprecated_on="2026-08-31",
     replacement="the energy_reg_weight/add_noise_to_real/noise_scale constructor parameters",
     message=(

--- a/torchebm/losses/equilibrium_matching.py
+++ b/torchebm/losses/equilibrium_matching.py
@@ -20,9 +20,13 @@ points from data toward noise (opposite of FM velocity).
 
 Key differences from Flow Matching:
 
-- Time-invariant: Model zeros out time conditioning internally
+- Time-invariant: the model receives a zeroed clock by default
+  (``model_time="zero"``); ``model_time="true"`` passes the sampled time
 - Gradient direction: EqM learns $(\epsilon - x)$, FM learns $(x - \epsilon)$
 - Sampling: Use ``negate_velocity=True`` with FlowSampler for ODE sampling
+
+The field-sign and clock conventions of both losses are tabulated in
+``docs/concepts/objectives.md``.
 """
 
 from __future__ import annotations
@@ -100,10 +104,11 @@ class EquilibriumMatchingLoss(BaseInterpolantLoss):
             - 'truncated' (default): $\min(1, (1-t)/(1-a))$, the EqM truncated decay
             - 'linear': $1 - t$, the $a \to 0$ endpoint of the truncated dial
             - 'constant': $1$, the $a \to 1$ endpoint; with ``ct_multiplier=1``
-              this is exactly the negated Flow Matching objective
+              and ``model_time="true"`` this is exactly the negated Flow
+              Matching objective (`FlowMatchingLoss(negate_velocity=True)`)
             - a callable ``t -> c(t)`` mapping a (batch_size,) time tensor to
               weights of the same shape
-              
+
         ct_threshold: Decay threshold $a$ for ct='truncated', strictly inside
             (0, 1); the endpoints are the 'linear' and 'constant' variants.
             Decay starts after $t > a$. Default: 0.8.
@@ -112,6 +117,18 @@ class EquilibriumMatchingLoss(BaseInterpolantLoss):
             is recorded on the loss (attribute and ``repr``). Default: 4.0.
         apply_dispersion: Whether to apply dispersive regularization.
         dispersion_weight: Weight for dispersive loss term.
+        model_time: Clock shown to the model at the training call and in the
+            conditioning probe:
+
+            - 'zero' (default): the EqM convention, the field is trained and
+              sampled at $t = 0$ (time-invariant)
+            - 'true': the sampled $t$ is passed, training a time-conditioned
+              field; sample it with ``FlowSampler(negate_velocity=True)``
+              (`EqMEnergy` evaluates the field at $t = 0$)
+            - a callable ``t -> t'`` mapping the (batch_size,) clock
+              elementwise, for schedules and reparametrisations; apply the
+              same map at sampling time
+
         dtype: Data type for computations.
         device: Device for computations.
 
@@ -165,6 +182,9 @@ class EquilibriumMatchingLoss(BaseInterpolantLoss):
         ct_multiplier: float = 4.0,
         apply_dispersion: bool = False,
         dispersion_weight: float = 0.5,
+        model_time: Union[
+            Literal["zero", "true"], Callable[[torch.Tensor], torch.Tensor]
+        ] = "zero",
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
         *args,
@@ -194,7 +214,13 @@ class EquilibriumMatchingLoss(BaseInterpolantLoss):
                 f"{ct_threshold}; use ct='linear' for the threshold -> 0 "
                 "endpoint or ct='constant' for the threshold -> 1 endpoint"
             )
+        if not callable(model_time) and model_time not in ("zero", "true"):
+            raise ValueError(
+                "model_time must be 'zero', 'true', or a callable t -> t', "
+                f"got {model_time!r}"
+            )
         self.model = model
+        self.model_time = model_time
         self.prediction = prediction
         self.energy_type = energy_type
         self.loss_weight = loss_weight
@@ -204,10 +230,16 @@ class EquilibriumMatchingLoss(BaseInterpolantLoss):
         self.apply_dispersion = apply_dispersion
         self.dispersion_weight = dispersion_weight
 
+    def _model_t(self, t: torch.Tensor) -> torch.Tensor:
+        r"""Clock shown to the model for the sampled time `t` (see `model_time`)."""
+        if callable(self.model_time):
+            return self.model_time(t)
+        return t if self.model_time == "true" else torch.zeros_like(t)
+
     def _probe_forward(self, px: torch.Tensor, pmk: dict) -> torch.Tensor:
-        r"""Field convention for the conditioning probe: zeroed time."""
+        r"""Field convention for the conditioning probe: the `model_time` clock at t = 0."""
         t0 = torch.zeros(px.shape[0], device=px.device, dtype=px.dtype)
-        return self.model(px, t0, **pmk)
+        return self.model(px, self._model_t(t0), **pmk)
 
     def _compute_ct(self, t: torch.Tensor) -> torch.Tensor:
         r"""Target scaling c(t) for the configured variant, times `ct_multiplier`."""
@@ -318,7 +350,8 @@ class EquilibriumMatchingLoss(BaseInterpolantLoss):
 
         Implements gradient matching with EqM target:
         - Target: $(\epsilon - x) \cdot c(t) = (x_0 - x_1) \cdot c(t)$
-        - Time-invariant: the model always receives zeroed time
+        - Clock: the model receives ``model_time`` applied to the sampled
+          $t$ (zeroed by default)
 
         Args:
             x1: Data samples of shape (batch_size, ...).
@@ -382,11 +415,8 @@ class EquilibriumMatchingLoss(BaseInterpolantLoss):
         if self.energy_type != "none":
             xt = xt.detach().requires_grad_(True)
 
-        # EqM: zero out time for time-invariance (model still receives t for API compat)
-        t_model = torch.zeros_like(t)
-
         with self.autocast_context():
-            model_output = self.model(xt, t_model, **model_kwargs)
+            model_output = self.model(xt, self._model_t(t), **model_kwargs)
 
         if isinstance(model_output, tuple):
             model_output, act = model_output
@@ -452,7 +482,8 @@ class EquilibriumMatchingLoss(BaseInterpolantLoss):
             f"interpolant={type(self.interpolant).__name__}, "
             f"coupling={type(self.coupling).__name__}, "
             f"ct={self.ct!r}, "
-            f"ct_multiplier={self.ct_multiplier})"
+            f"ct_multiplier={self.ct_multiplier}, "
+            f"model_time={self.model_time!r})"
         )
 
 

--- a/torchebm/losses/flow_matching.py
+++ b/torchebm/losses/flow_matching.py
@@ -11,9 +11,10 @@ x_t, u_t = \mathrm{interpolant}(x_0, x_1, t)
 with \(x_0\) noise (or any source batch) and \(x_1\) data. Sampling integrates
 the learned velocity forward with `FlowSampler` (no ``negate_velocity``).
 
-Relation to Equilibrium Matching: with ``ct="constant"`` and
-``ct_multiplier=1`` the EqM objective is exactly this loss with the field
-negated and the time conditioning zeroed.
+Relation to Equilibrium Matching: ``negate_velocity=True`` regresses onto
+\(-u_t\), which is exactly ``EquilibriumMatchingLoss(ct="constant",
+ct_multiplier=1, model_time="true")``. The field-sign and clock conventions
+of both losses are tabulated in ``docs/concepts/objectives.md``.
 """
 
 from __future__ import annotations
@@ -33,7 +34,7 @@ class FlowMatchingLoss(BaseInterpolantLoss):
 
     Trains ``model(x_t, t, **model_kwargs)`` to predict the interpolant
     velocity \(u_t\). The model receives the true training time (unlike
-    `EquilibriumMatchingLoss`, whose field is time-invariant).
+    `EquilibriumMatchingLoss`, whose field is time-invariant by default).
 
     Args:
         model: Neural network predicting velocity, called as ``model(x, t)``.
@@ -51,6 +52,11 @@ class FlowMatchingLoss(BaseInterpolantLoss):
         t_p_std: Lognormal skew scale $p_{std}$, positive. Default: 1.2.
         loss_weight_fn: Optional per-timestep weight hook ``t -> w(t)``
             multiplied into the per-sample loss.
+        negate_velocity: Regress onto \(-u_t\) (data -> noise) instead of
+            \(u_t\), the sign the gradient-descent samplers and `EqMEnergy`
+            assume, so the trained field drops into them without a wrapper.
+            Sample it with ``FlowSampler(negate_velocity=True)``. Mirrors the
+            sampler flag of the same name. Default False.
         dtype: Data type for computations.
         device: Device for computations.
 
@@ -80,6 +86,7 @@ class FlowMatchingLoss(BaseInterpolantLoss):
         t_p_mean: float = -1.2,
         t_p_std: float = 1.2,
         loss_weight_fn: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
+        negate_velocity: bool = False,
         dtype: torch.dtype = torch.float32,
         device: Optional[Union[str, torch.device]] = None,
         *args,
@@ -99,6 +106,7 @@ class FlowMatchingLoss(BaseInterpolantLoss):
             **kwargs,
         )
         self.model = model
+        self.negate_velocity = bool(negate_velocity)
 
     def _probe_forward(self, px: torch.Tensor, pmk: dict) -> torch.Tensor:
         r"""Field convention for the conditioning probe: fixed mid-path time."""
@@ -181,13 +189,14 @@ class FlowMatchingLoss(BaseInterpolantLoss):
 
         t = self._sample_t(batch, generator)
         xt, ut = self.interpolant.interpolate(x0, x1, t)
+        target = -ut if self.negate_velocity else ut
 
         with self.autocast_context():
             pred = self.model(xt, t, **model_kwargs)
         if isinstance(pred, tuple):
             pred = pred[0]
 
-        loss = mean_flat((pred - ut).square())
+        loss = mean_flat((pred - target).square())
         if self.loss_weight_fn is not None:
             loss = loss * self.loss_weight_fn(t)
 
@@ -198,7 +207,8 @@ class FlowMatchingLoss(BaseInterpolantLoss):
             f"{self.__class__.__name__}("
             f"interpolant={type(self.interpolant).__name__}, "
             f"coupling={type(self.coupling).__name__}, "
-            f"t_sampler={self.t_sampler!r})"
+            f"t_sampler={self.t_sampler!r}, "
+            f"negate_velocity={self.negate_velocity})"
         )
 
 

--- a/torchebm/models/conditional_transformer_2d.py
+++ b/torchebm/models/conditional_transformer_2d.py
@@ -9,7 +9,7 @@ from torchebm.models.dit import DiT
 
 
 @deprecated(
-    since="0.8.4",
+    since="0.8.5",
     deprecated_on="2026-08-30",
     replacement="torchebm.models.DiT",
     message=(

--- a/torchebm/samplers/flow.py
+++ b/torchebm/samplers/flow.py
@@ -33,7 +33,7 @@ from torchebm.interpolants.interpolant_utils import resolve_interpolant
 _BARE_SAMPLE_KWARGS_DEPRECATION = declare_deprecation(
     module=__name__,
     name="FlowSampler.sample bare conditioning kwargs",
-    since="0.8.4",
+    since="0.8.5",
     deprecated_on="2026-08-31",
     replacement="model_kwargs={...}",
     message=(

--- a/torchebm/samplers/hmc.py
+++ b/torchebm/samplers/hmc.py
@@ -20,7 +20,7 @@ from torchebm.integrators.integrator_utils import resolve_integrator
 _SOLVER_ARGS_DEPRECATION = declare_deprecation(
     module=__name__,
     name="RiemannianManifoldHMC solver_max_iter/solver_tol/solver_check_every",
-    since="0.8.4",
+    since="0.8.5",
     deprecated_on="2026-08-31",
     replacement="GeneralisedLeapfrogIntegrator(solver_max_iter=..., ...) passed as integrator=",
     message=(


### PR DESCRIPTION
EquilibriumMatchingLoss gains model_time ('zero' default, 'true', or a callable t -> t') controlling the clock shown to the model at the training call and in the conditioning probe, restoring time-conditioned training. FlowMatchingLoss gains negate_velocity so a field trained with it drops into the descent samplers and EqMEnergy; with ct='constant', ct_multiplier=1 and model_time='true' the two objectives are bit-identical, which is pinned by tests. The field-sign and clock conventions of both losses are tabulated in the objectives concept page. Deprecation since stamps are corrected to the 0.8.5 release that shipped the warnings.

resolves #283
resolves #284