### PR TITLE
trimmed_mean: use topk instead of a full sort

### DIFF
--- a/torchebm/losses/loss_utils.py
+++ b/torchebm/losses/loss_utils.py
@@ -41,7 +41,7 @@ def trimmed_mean(values: torch.Tensor, trim_fraction: float) -> torch.Tensor:
     k = int(trim_fraction * n)
     if k == 0:
         return values.mean()
-    return values.sort().values[: n - k].mean()
+    return torch.topk(values, n - k, largest=False).values.mean()
 
 
 def compute_flow_weight(t: torch.Tensor, cutoff: float = 0.8) -> torch.Tensor:


### PR DESCRIPTION
## Summary
trimmed_mean sorted the entire tensor just to discard the top k largest
entries before averaging. Since we only need the set of kept values (not
a full ordering), torch.topk(values, n - k, largest=False) gets the same
result without the full sort.

## Test plan
- [x] Existing trimmed_mean test in tests/losses/test_energy_matching.py passes
- [x] Full test_energy_matching.py suite passes (28 passed, 3 skipped - no CUDA)

Closes #290