### PR TITLE
build(packaging): ship py.typed marker for PEP 561 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,3 +152,6 @@ multi_line_output = 3
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["torchebm*"]
+
+[tool.setuptools.package-data]
+torchebm = ["py.typed"]


### PR DESCRIPTION
## Summary
The package is fully annotated but had no py.typed marker, so mypy/pyright
treated torchebm as untyped downstream. Added torchebm/py.typed and
registered it under [tool.setuptools.package-data] so it ships in the wheel.

## Test plan
- [x] Built the wheel locally and confirmed torchebm/py.typed is present in it
- [x] Installed the built wheel and ran mypy --strict against a script importing
      from torchebm; it now resolves the real signature instead of treating
      the package as untyped

Closes #178