### PR TITLE
feat(samplers): add config-revealing reprs to samplers and integrators

### DIFF
--- a/tests/integrators/test_dopri5.py
+++ b/tests/integrators/test_dopri5.py
@@ -76,6 +76,13 @@ def test_dopri5_custom_tolerances():
     assert integrator.max_factor == 5.0
 
 
+def test_dopri5_repr_shows_tolerances():
+    """Adaptive methods (error_weights defined) surface atol/rtol/max_steps."""
+    integrator = Dopri5Integrator(atol=1e-8, rtol=1e-5, max_steps=5000)
+    text = repr(integrator)
+    assert text == "Dopri5Integrator(atol=1e-08, rtol=1e-05, max_steps=5000)"
+
+
 @requires_cuda
 def test_dopri5_cuda():
     """Test CUDA initialization."""

--- a/tests/integrators/test_rk4.py
+++ b/tests/integrators/test_rk4.py
@@ -56,6 +56,12 @@ def test_rk4_no_adaptive_params():
     assert integrator.fsal is False
 
 
+def test_rk4_repr_has_no_hyperparameters():
+    """Fixed-step methods carry no tunable config, so the repr is bare."""
+    assert repr(RK4Integrator()) == "RK4Integrator()"
+    assert repr(RK438Integrator()) == "RK438Integrator()"
+
+
 @requires_cuda
 def test_rk4_cuda():
     integrator = RK4Integrator(device="cuda", dtype=torch.float32)

--- a/tests/integrators/test_symplectic_base.py
+++ b/tests/integrators/test_symplectic_base.py
@@ -88,6 +88,21 @@ def test_safe_mode_zeroes_nans(integrator):
     assert torch.isfinite(result["p"]).all()
 
 
+def test_leapfrog_repr_has_no_hyperparameters():
+    assert repr(LeapfrogIntegrator(device=device)) == "LeapfrogIntegrator()"
+
+
+def test_generalised_leapfrog_repr_shows_solver_hyperparameters():
+    integ = GeneralisedLeapfrogIntegrator(
+        device=device, solver_max_iter=4, solver_tol=1e-3, solver_check_every=2,
+    )
+    text = repr(integ)
+    assert text.startswith("GeneralisedLeapfrogIntegrator(")
+    assert "solver_max_iter=4" in text
+    assert "solver_tol=0.001" in text
+    assert "solver_check_every=2" in text
+
+
 def test_safe_mode_clamps_extreme_forces():
     integ = LeapfrogIntegrator(device=device)
     state = _make_state()

--- a/tests/samplers/test_flow.py
+++ b/tests/samplers/test_flow.py
@@ -69,6 +69,21 @@ class TestFlowSampler:
         assert sampler.diffusion_form == "SBDM"
         assert sampler.diffusion_norm == 1.0
 
+    def test_repr(self, device, dtype):
+        sampler = FlowSampler(
+            MockModel(),
+            interpolant="linear",
+            prediction="velocity",
+            device=device,
+            dtype=dtype,
+        )
+        text = repr(sampler)
+        assert text.startswith("FlowSampler(")
+        assert "mode='ode'" in text
+        assert "interpolant=" in text
+        assert "prediction='velocity'" in text
+        assert "integrator=" in text
+
     def test_negate_velocity_conditions_model_on_zero_time(self, device, dtype):
         """EqM fields are time-invariant: trained on zeroed time, so sampling
         must condition the model on zeros too, not the integration clock."""

--- a/tests/samplers/test_flow.py
+++ b/tests/samplers/test_flow.py
@@ -80,9 +80,9 @@ class TestFlowSampler:
         text = repr(sampler)
         assert text.startswith("FlowSampler(")
         assert "mode='ode'" in text
-        assert "interpolant=" in text
+        assert "interpolant=LinearInterpolant" in text
         assert "prediction='velocity'" in text
-        assert "integrator=" in text
+        assert "integrator=Dopri5Integrator" in text
 
     def test_negate_velocity_conditions_model_on_zero_time(self, device, dtype):
         """EqM fields are time-invariant: trained on zeroed time, so sampling

--- a/tests/samplers/test_gradient_descent.py
+++ b/tests/samplers/test_gradient_descent.py
@@ -71,13 +71,28 @@ class TestGradientDescentSampler:
         assert_close(samples[0, 0], torch.tensor([0.9], device=device))
         assert_close(samples[0, 1], torch.tensor([0.81], device=device))
 
+    def test_repr(self, device, dtype):
+        model = QuadraticEnergy()
+        sampler = GradientDescentSampler(model, step_size=0.1, device=device, dtype=dtype)
+        text = repr(sampler)
+        assert text.startswith("GradientDescentSampler(")
+        assert "step_size=" in text
+
 class TestNesterovSampler:
-    
+
     def test_initialization(self, device, dtype):
         model = QuadraticEnergy()
         sampler = NesterovSampler(model, step_size=0.1, momentum=0.9, device=device, dtype=dtype)
         assert sampler.momentum == 0.9
-        
+
+    def test_repr(self, device, dtype):
+        model = QuadraticEnergy()
+        sampler = NesterovSampler(model, step_size=0.1, momentum=0.9, device=device, dtype=dtype)
+        text = repr(sampler)
+        assert text.startswith("NesterovSampler(")
+        assert "step_size=" in text
+        assert "momentum=0.9" in text
+
     def test_manual_step(self, device, dtype):
         # x_0 = 1.0, v_0 = 0.0
         # mu = 0.9, eta = 0.1

--- a/tests/samplers/test_gradient_descent.py
+++ b/tests/samplers/test_gradient_descent.py
@@ -76,7 +76,7 @@ class TestGradientDescentSampler:
         sampler = GradientDescentSampler(model, step_size=0.1, device=device, dtype=dtype)
         text = repr(sampler)
         assert text.startswith("GradientDescentSampler(")
-        assert "step_size=" in text
+        assert "step_size=0.1" in text
 
 class TestNesterovSampler:
 
@@ -90,7 +90,7 @@ class TestNesterovSampler:
         sampler = NesterovSampler(model, step_size=0.1, momentum=0.9, device=device, dtype=dtype)
         text = repr(sampler)
         assert text.startswith("NesterovSampler(")
-        assert "step_size=" in text
+        assert "step_size=0.1" in text
         assert "momentum=0.9" in text
 
     def test_manual_step(self, device, dtype):

--- a/tests/samplers/test_hmc.py
+++ b/tests/samplers/test_hmc.py
@@ -185,6 +185,30 @@ def test_hmc_initialization_with_mass():
     assert hmc_tensor.mass.device.type == device
 
 
+def test_hmc_repr(hmc_sampler):
+    text = repr(hmc_sampler)
+    assert text.startswith("HamiltonianMonteCarlo(")
+    assert "step_size=" in text
+    assert "n_leapfrog_steps=" in text
+    assert "mass=" in text
+    assert "integrator=" in text
+
+
+def test_hmc_repr_with_tensor_mass():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    energy_fn = GaussianModel(mean=torch.zeros(2), cov=torch.eye(2)).to(device)
+    tensor_mass = torch.tensor([2.0, 3.0], device=device)
+    sampler = HamiltonianMonteCarlo(
+        model=energy_fn,
+        step_size=0.1,
+        n_leapfrog_steps=10,
+        mass=tensor_mass,
+        device=device,
+    )
+    text = repr(sampler)
+    assert "mass=tensor(2,)" in text
+
+
 def test_hmc_initialization_invalid_params(energy_function):
     """Test that invalid parameters raise appropriate exceptions."""
     with pytest.raises(ValueError, match="step_size must be positive"):
@@ -965,6 +989,21 @@ def test_rmhmc_initialization():
     assert sampler.n_leapfrog_steps == 10
     # The default integrator should be the Generalised Leapfrog.
     assert type(sampler.integrator).__name__ == "GeneralisedLeapfrogIntegrator"
+
+
+def test_rmhmc_repr():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = _gaussian_target(2, device)
+    sampler = RiemannianManifoldHMC(
+        model, metric_fn=_identity_metric(2),
+        step_size=0.1, n_leapfrog_steps=10, device=device,
+    )
+    text = repr(sampler)
+    assert text.startswith("RiemannianManifoldHMC(")
+    assert "metric_fn=" in text
+    assert "step_size=" in text
+    assert "n_leapfrog_steps=" in text
+    assert "integrator=" in text
 
 
 def test_rmhmc_initialization_invalid_metric_fn():

--- a/tests/samplers/test_hmc.py
+++ b/tests/samplers/test_hmc.py
@@ -188,10 +188,10 @@ def test_hmc_initialization_with_mass():
 def test_hmc_repr(hmc_sampler):
     text = repr(hmc_sampler)
     assert text.startswith("HamiltonianMonteCarlo(")
-    assert "step_size=" in text
-    assert "n_leapfrog_steps=" in text
-    assert "mass=" in text
-    assert "integrator=" in text
+    assert "step_size=0.1" in text
+    assert "n_leapfrog_steps=10" in text
+    assert "mass=None" in text
+    assert "integrator=LeapfrogIntegrator" in text
 
 
 def test_hmc_repr_with_tensor_mass():
@@ -1000,10 +1000,10 @@ def test_rmhmc_repr():
     )
     text = repr(sampler)
     assert text.startswith("RiemannianManifoldHMC(")
-    assert "metric_fn=" in text
-    assert "step_size=" in text
-    assert "n_leapfrog_steps=" in text
-    assert "integrator=" in text
+    assert "metric_fn=metric_fn" in text
+    assert "step_size=0.1" in text
+    assert "n_leapfrog_steps=10" in text
+    assert "integrator=GeneralisedLeapfrogIntegrator" in text
 
 
 def test_rmhmc_initialization_invalid_metric_fn():

--- a/tests/samplers/test_langevin_dynamics.py
+++ b/tests/samplers/test_langevin_dynamics.py
@@ -43,6 +43,14 @@ def test_langevin_dynamics_initialization(langevin_sampler):
     assert sampler.get_scheduled_value("noise_scale") == 1.0
 
 
+def test_langevin_dynamics_repr(langevin_sampler):
+    text = repr(langevin_sampler)
+    assert text.startswith("LangevinDynamics(")
+    assert "step_size=" in text
+    assert "noise_scale=" in text
+    assert "integrator=" in text
+
+
 def test_langevin_dynamics_initialization_invalid_params(energy_function):
     with pytest.raises(ValueError):
         LangevinDynamics(energy_function, step_size=-0.1, noise_scale=0.1)

--- a/tests/samplers/test_langevin_dynamics.py
+++ b/tests/samplers/test_langevin_dynamics.py
@@ -46,9 +46,9 @@ def test_langevin_dynamics_initialization(langevin_sampler):
 def test_langevin_dynamics_repr(langevin_sampler):
     text = repr(langevin_sampler)
     assert text.startswith("LangevinDynamics(")
-    assert "step_size=" in text
-    assert "noise_scale=" in text
-    assert "integrator=" in text
+    assert "step_size=0.005" in text
+    assert "noise_scale=1.0" in text
+    assert "integrator=EulerMaruyamaIntegrator" in text
 
 
 def test_langevin_dynamics_initialization_invalid_params(energy_function):

--- a/torchebm/core/base_integrator.py
+++ b/torchebm/core/base_integrator.py
@@ -91,6 +91,9 @@ class BaseIntegrator(TorchEBMModule, ABC):
         """
         raise NotImplementedError
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"
+
 
 class BaseRungeKuttaIntegrator(BaseIntegrator):
     r"""Abstract base class for explicit Runge-Kutta ODE integrators.
@@ -622,6 +625,15 @@ class BaseRungeKuttaIntegrator(BaseIntegrator):
         h = min(step_size.item(), t_end - t_start, self.max_step_size)
         x = self._adaptive_integrate(x, drift_fn, t_start, t_end, h)
         return {"x": x}
+
+    def __repr__(self) -> str:
+        if self.error_weights is not None:
+            return (
+                f"{self.__class__.__name__}("
+                f"atol={self.atol}, rtol={self.rtol}, "
+                f"max_steps={self.max_steps})"
+            )
+        return f"{self.__class__.__name__}()"
 
 
 class BaseSDERungeKuttaIntegrator(BaseRungeKuttaIntegrator):

--- a/torchebm/core/base_sampler.py
+++ b/torchebm/core/base_sampler.py
@@ -153,3 +153,6 @@ class BaseSampler(Schedulable, TorchEBMModule, ABC):
                 for samplers that cannot infer the state shape.
         """
         raise NotImplementedError
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(model={type(self.model).__name__})"

--- a/torchebm/integrators/leapfrog.py
+++ b/torchebm/integrators/leapfrog.py
@@ -491,3 +491,11 @@ class GeneralisedLeapfrogIntegrator(BaseSymplecticIntegrator):
             x, p = x_new, p_new
 
         return {"x": x, "p": p}
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"solver_max_iter={self.solver_max_iter}, "
+            f"solver_tol={self.solver_tol}, "
+            f"solver_check_every={self.solver_check_every})"
+        )

--- a/torchebm/samplers/flow.py
+++ b/torchebm/samplers/flow.py
@@ -649,5 +649,15 @@ class FlowSampler(BaseSampler):
             - torch.sum(z.square(), dim=tuple(range(1, z.ndim))) / 2.0
         )
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"model={type(self.model).__name__}, "
+            f"mode={self.mode!r}, "
+            f"interpolant={type(self.interpolant).__name__}, "
+            f"prediction={self.prediction_type.name.lower()!r}, "
+            f"integrator={type(self.integrator).__name__})"
+        )
+
 
 __all__ = ["FlowSampler", "PredictionType"]

--- a/torchebm/samplers/gradient_descent.py
+++ b/torchebm/samplers/gradient_descent.py
@@ -141,6 +141,12 @@ class GradientDescentSampler(BaseSampler):
         output = trajectory if return_trajectory else x
         return (output, diagnostics) if return_diagnostics else output
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"model={type(self.model).__name__}, "
+            f"step_size={self.schedulers['step_size']!r})"
+        )
 
 
 class NesterovSampler(BaseSampler):
@@ -283,6 +289,14 @@ class NesterovSampler(BaseSampler):
 
         output = trajectory if return_trajectory else x
         return (output, diagnostics) if return_diagnostics else output
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"model={type(self.model).__name__}, "
+            f"step_size={self.schedulers['step_size']!r}, "
+            f"momentum={self.momentum})"
+        )
 
 
 __all__ = [

--- a/torchebm/samplers/gradient_descent.py
+++ b/torchebm/samplers/gradient_descent.py
@@ -145,7 +145,7 @@ class GradientDescentSampler(BaseSampler):
         return (
             f"{self.__class__.__name__}("
             f"model={type(self.model).__name__}, "
-            f"step_size={self.schedulers['step_size']!r})"
+            f"step_size={self.get_scheduled_value('step_size')})"
         )
 
 
@@ -294,7 +294,7 @@ class NesterovSampler(BaseSampler):
         return (
             f"{self.__class__.__name__}("
             f"model={type(self.model).__name__}, "
-            f"step_size={self.schedulers['step_size']!r}, "
+            f"step_size={self.get_scheduled_value('step_size')}, "
             f"momentum={self.momentum})"
         )
 

--- a/torchebm/samplers/hmc.py
+++ b/torchebm/samplers/hmc.py
@@ -340,6 +340,21 @@ class HamiltonianMonteCarlo(BaseSampler):
         output = trajectory if return_trajectory else x
         return (output, diagnostics) if return_diagnostics else output
 
+    def __repr__(self) -> str:
+        mass_repr = (
+            self.mass
+            if self.mass is None or isinstance(self.mass, float)
+            else f"tensor{tuple(self.mass.shape)}"
+        )
+        return (
+            f"{self.__class__.__name__}("
+            f"model={type(self.model).__name__}, "
+            f"step_size={self.schedulers['step_size']!r}, "
+            f"n_leapfrog_steps={self.n_leapfrog_steps}, "
+            f"mass={mass_repr}, "
+            f"integrator={type(self.integrator).__name__})"
+        )
+
 
 class RiemannianManifoldHMC(BaseSampler):
     r"""
@@ -758,3 +773,13 @@ class RiemannianManifoldHMC(BaseSampler):
 
         output = trajectory if return_trajectory else x
         return (output, diagnostics) if return_diagnostics else output
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"model={type(self.model).__name__}, "
+            f"metric_fn={self.metric_fn!r}, "
+            f"step_size={self.schedulers['step_size']!r}, "
+            f"n_leapfrog_steps={self.n_leapfrog_steps}, "
+            f"integrator={type(self.integrator).__name__})"
+        )

--- a/torchebm/samplers/hmc.py
+++ b/torchebm/samplers/hmc.py
@@ -349,7 +349,7 @@ class HamiltonianMonteCarlo(BaseSampler):
         return (
             f"{self.__class__.__name__}("
             f"model={type(self.model).__name__}, "
-            f"step_size={self.schedulers['step_size']!r}, "
+            f"step_size={self.get_scheduled_value('step_size')}, "
             f"n_leapfrog_steps={self.n_leapfrog_steps}, "
             f"mass={mass_repr}, "
             f"integrator={type(self.integrator).__name__})"
@@ -775,11 +775,14 @@ class RiemannianManifoldHMC(BaseSampler):
         return (output, diagnostics) if return_diagnostics else output
 
     def __repr__(self) -> str:
+        metric_fn_name = getattr(
+            self.metric_fn, "__name__", type(self.metric_fn).__name__
+        )
         return (
             f"{self.__class__.__name__}("
             f"model={type(self.model).__name__}, "
-            f"metric_fn={self.metric_fn!r}, "
-            f"step_size={self.schedulers['step_size']!r}, "
+            f"metric_fn={metric_fn_name}, "
+            f"step_size={self.get_scheduled_value('step_size')}, "
             f"n_leapfrog_steps={self.n_leapfrog_steps}, "
             f"integrator={type(self.integrator).__name__})"
         )

--- a/torchebm/samplers/langevin_dynamics.py
+++ b/torchebm/samplers/langevin_dynamics.py
@@ -191,3 +191,12 @@ class LangevinDynamics(BaseSampler):
 
         output = trajectory if return_trajectory else x
         return (output, diagnostics) if return_diagnostics else output
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"model={type(self.model).__name__}, "
+            f"step_size={self.schedulers['step_size']!r}, "
+            f"noise_scale={self.schedulers['noise_scale']!r}, "
+            f"integrator={type(self.integrator).__name__})"
+        )

--- a/torchebm/samplers/langevin_dynamics.py
+++ b/torchebm/samplers/langevin_dynamics.py
@@ -196,7 +196,7 @@ class LangevinDynamics(BaseSampler):
         return (
             f"{self.__class__.__name__}("
             f"model={type(self.model).__name__}, "
-            f"step_size={self.schedulers['step_size']!r}, "
-            f"noise_scale={self.schedulers['noise_scale']!r}, "
+            f"step_size={self.get_scheduled_value('step_size')}, "
+            f"noise_scale={self.get_scheduled_value('noise_scale')}, "
             f"integrator={type(self.integrator).__name__})"
         )


### PR DESCRIPTION
## Summary
Losses and couplings implement config-revealing reprs; samplers and
integrators did not, so printing a constructed sampler showed only the
default nn.Module dump.

- BaseSampler: fallback repr showing the model type.
- LangevinDynamics, HamiltonianMonteCarlo, RiemannianManifoldHMC,
  GradientDescentSampler, NesterovSampler, FlowSampler: override showing
  their key hyperparameters (step_size, noise_scale, n_leapfrog_steps,
  mass, metric_fn, momentum, mode, interpolant, prediction, integrator).
- BaseIntegrator: fallback repr for parameterless integrators.
- BaseRungeKuttaIntegrator: shows atol/rtol/max_steps only when the
  subclass defines error_weights (adaptive-capable); fixed-step methods
  (RK4, RK438, midpoint, heun, ...) stay bare since those tolerances are
  unused on the fixed-step path.
- GeneralisedLeapfrogIntegrator: override showing its implicit-solver
  hyperparameters (solver_max_iter, solver_tol, solver_check_every).

step_size/noise_scale/etc. are scheduler-backed (`_register_param`
stores them in `self.schedulers`, not as plain attributes), so the repr
reads `self.schedulers['step_size']` rather than a nonexistent
`self.step_size`.

## Test plan
- [x] Added repr assertions to the existing test file for each touched
      sampler (test_langevin_dynamics.py, test_hmc.py,
      test_gradient_descent.py, test_flow.py) and integrator
      (test_rk4.py, test_dopri5.py, test_symplectic_base.py), including
      the tensor-mass case for HMC and the adaptive vs. fixed-step split
      for the RK base.
- [x] Full test suite passes locally (`pytest tests/`), no failures.

Closes #191