### PR TITLE
fix(losses): Restore per-module training modes

### DIFF
--- a/tests/losses/test_condition_probe.py
+++ b/tests/losses/test_condition_probe.py
@@ -154,12 +154,14 @@ def test_uniform_labels_warn_and_disarm():
     assert torch.isfinite(loss_fn(torch.randn(8, 4), y=_distinct_y()))
 
 
-def test_probe_restores_training_mode():
+def test_probe_restores_per_module_training_modes():
     model = ConsumingField()
     model.train()
+    model.linear.eval()
     loss_fn = EquilibriumMatchingLoss(model=model)
     loss_fn(torch.randn(8, 4), y=_distinct_y())
     assert model.training
+    assert not model.linear.training
 
 
 def test_zero_init_output_defers_probe():

--- a/torchebm/core/base_loss.py
+++ b/torchebm/core/base_loss.py
@@ -178,14 +178,15 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
             for k, v in model_kwargs.items()
             if k != "y"
         }
-        was_training = self.model.training
+        training_states = {module: module.training for module in self.model.modules()}
         self.model.eval()
         try:
             with torch.no_grad():
                 out_a = self._probe_forward(px, {**pmk, "y": y[0:1]})
                 out_b = self._probe_forward(px, {**pmk, "y": y[i1 : i1 + 1]})
         finally:
-            self.model.train(was_training)
+            for module, training in training_states.items():
+                module.training = training
         if isinstance(out_a, tuple):
             out_a = out_a[0]
         if isinstance(out_b, tuple):


### PR DESCRIPTION
## Summary

- preserve every module's training flag before the conditioning probe enters eval mode
- restore flags directly so intentionally eval-mode children remain in eval mode
- cover a training parent with an eval-mode child

Closes #303.

## Validation

- `pytest tests/losses/test_condition_probe.py -q`
- `pytest tests -q` (all passed; 2 expected skips)
- `git diff --check`