### PR TITLE
fix(losses): restore nested module training flags

### DIFF
--- a/tests/losses/test_condition_probe.py
+++ b/tests/losses/test_condition_probe.py
@@ -164,6 +164,22 @@ def test_probe_restores_per_module_training_modes():
     assert not model.linear.training
 
 
+def test_probe_restores_per_module_training_modes_after_error():
+    model = ConsumingField()
+    model.train()
+    model.linear.eval()
+    loss_fn = EquilibriumMatchingLoss(model=model)
+
+    def fail_probe(*args, **kwargs):
+        raise RuntimeError("probe failed")
+
+    loss_fn._probe_forward = fail_probe
+    with pytest.raises(RuntimeError, match="probe failed"):
+        loss_fn._check_condition(torch.randn(8, 4), {"y": _distinct_y()})
+    assert model.training
+    assert not model.linear.training
+
+
 def test_zero_init_output_defers_probe():
     model = ZeroInitField(consumes_y=True)
     loss_fn = FlowMatchingLoss(model=model)

--- a/tests/losses/test_condition_probe.py
+++ b/tests/losses/test_condition_probe.py
@@ -154,12 +154,30 @@ def test_uniform_labels_warn_and_disarm():
     assert torch.isfinite(loss_fn(torch.randn(8, 4), y=_distinct_y()))
 
 
-def test_probe_restores_training_mode():
+def test_probe_restores_each_module_training_mode():
     model = ConsumingField()
     model.train()
+    model.linear.eval()
+    training_flags = {module: module.training for module in model.modules()}
     loss_fn = EquilibriumMatchingLoss(model=model)
     loss_fn(torch.randn(8, 4), y=_distinct_y())
-    assert model.training
+    assert {module: module.training for module in model.modules()} == training_flags
+
+
+def test_probe_restores_each_module_training_mode_after_error():
+    model = ConsumingField()
+    model.train()
+    model.linear.eval()
+    training_flags = {module: module.training for module in model.modules()}
+    loss_fn = EquilibriumMatchingLoss(model=model)
+
+    def fail_probe(*args, **kwargs):
+        raise RuntimeError("probe failed")
+
+    loss_fn._probe_forward = fail_probe
+    with pytest.raises(RuntimeError, match="probe failed"):
+        loss_fn._check_condition(torch.randn(8, 4), {"y": _distinct_y()})
+    assert {module: module.training for module in model.modules()} == training_flags
 
 
 def test_zero_init_output_defers_probe():

--- a/torchebm/core/base_loss.py
+++ b/torchebm/core/base_loss.py
@@ -139,7 +139,9 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
         Runs on the first conditional call: the same one-sample input under
         two distinct in-batch y values (never fabricated labels, which could
         index outside an embedding), model temporarily in eval mode,
-        gradients off. Identical nonzero outputs on a fresh model raise.
+        gradients off. Every module's training flag is restored independently,
+        preserving intentionally mixed train/eval subtrees. Identical nonzero
+        outputs on a fresh model raise.
         Identical all-zero outputs are indeterminate, the signature of a
         zero-initialized output head: adaLN-Zero models emit exactly zero
         until trained, and their y-dependence surfaces only a few optimizer
@@ -178,14 +180,17 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
             for k, v in model_kwargs.items()
             if k != "y"
         }
-        was_training = self.model.training
+        training_flags = {
+            module: module.training for module in self.model.modules()
+        }
         self.model.eval()
         try:
             with torch.no_grad():
                 out_a = self._probe_forward(px, {**pmk, "y": y[0:1]})
                 out_b = self._probe_forward(px, {**pmk, "y": y[i1 : i1 + 1]})
         finally:
-            self.model.train(was_training)
+            for module, training in training_flags.items():
+                module.training = training
         if isinstance(out_a, tuple):
             out_a = out_a[0]
         if isinstance(out_b, tuple):


### PR DESCRIPTION
Closes #303.

The conditioning probe now saves and restores every module’s training flag, preserving intentionally eval-mode children inside train-mode parents. Regression coverage checks both successful and failing probe paths.

Validation: 1,755 passed, 80 skipped; focused conditioning tests 16 passed.

AI-assisted contribution; I reviewed the implementation and test results.
