### PR TITLE
perf(losses): use topk for trimmed mean

### DIFF
--- a/torchebm/losses/loss_utils.py
+++ b/torchebm/losses/loss_utils.py
@@ -41,7 +41,7 @@ def trimmed_mean(values: torch.Tensor, trim_fraction: float) -> torch.Tensor:
     k = int(trim_fraction * n)
     if k == 0:
         return values.mean()
-    return values.sort().values[: n - k].mean()
+    return torch.topk(values, n - k, largest=False, sorted=False).values.mean()
 
 
 def compute_flow_weight(t: torch.Tensor, cutoff: float = 0.8) -> torch.Tensor:


### PR DESCRIPTION
## Summary

- select only the retained values with `torch.topk`
- avoid fully sorting the input for the one-sided trimmed mean
- preserve the existing zero-trim fast path and result semantics

## Validation

- `pytest tests/losses/test_energy_matching.py -q`
- `pytest tests/ -q`
- `black --check torchebm/losses/loss_utils.py`
- `isort --check-only torchebm/losses/loss_utils.py`

Closes #290