### PR TITLE
feat(models): add analytic energy landscapes

### DIFF
--- a/tests/core/test_base_model.py
+++ b/tests/core/test_base_model.py
@@ -4,11 +4,14 @@ import torch
 from torchebm.core.base_model import (
     AckleyModel,
     BaseModel,
+    BoothModel,
     DoubleWellModel,
     GaussianModel,
     HarmonicModel,
+    HimmelblauModel,
     RastriginModel,
     RosenbrockModel,
+    StyblinskiTangModel,
 )
 
 
@@ -108,6 +111,44 @@ def test_rastrigin_energy_zero_at_origin():
     m = RastriginModel()
     x = torch.zeros(1, 3)
     assert torch.allclose(m(x), torch.zeros(1), atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "model,minimum,origin_energy",
+    [
+        (HimmelblauModel(), [3.0, 2.0], 170.0),
+        (BoothModel(), [1.0, 3.0], 74.0),
+    ],
+)
+def test_two_dimensional_landscape_batch_values(model, minimum, origin_energy):
+    x = torch.tensor([minimum, [0.0, 0.0]])
+    assert torch.allclose(model(x), torch.tensor([0.0, origin_energy]), atol=1e-6)
+
+
+@pytest.mark.parametrize("model", [HimmelblauModel(), BoothModel()])
+def test_two_dimensional_landscape_rejects_wrong_dimension(model):
+    with pytest.raises(ValueError, match="requires 2 dimensions"):
+        model(torch.randn(3, 4))
+
+
+def test_styblinski_tang_is_vectorized_over_batches():
+    model = StyblinskiTangModel()
+    x = torch.tensor([[0.0, 0.0], [1.0, -2.0]])
+    assert torch.allclose(model(x), torch.tensor([0.0, -34.0]))
+
+
+@pytest.mark.parametrize(
+    "model,x,expected_gradient",
+    [
+        (HimmelblauModel(), [1.0, -1.0], [-54.0, -2.0]),
+        (BoothModel(), [-1.0, 2.0], [-28.0, -26.0]),
+        (StyblinskiTangModel(), [1.0, -2.0], [-11.5, 18.5]),
+    ],
+)
+def test_analytic_landscape_gradient(model, x, expected_gradient):
+    x = torch.tensor([x])
+    expected = torch.tensor([expected_gradient])
+    assert torch.allclose(model.gradient(x), expected)
 
 
 def test_harmonic_gradient_linear_in_x():

--- a/tests/models/test_constructor_kwargs.py
+++ b/tests/models/test_constructor_kwargs.py
@@ -12,11 +12,14 @@ import torch.nn as nn
 from torchebm import __version__
 from torchebm.core import (
     AckleyModel,
+    BoothModel,
     DoubleWellModel,
     GaussianModel,
     HarmonicModel,
+    HimmelblauModel,
     RastriginModel,
     RosenbrockModel,
+    StyblinskiTangModel,
 )
 from torchebm.models import (
     ClassifierFreeGuidance,
@@ -44,6 +47,15 @@ CASCADING = [
     pytest.param(RosenbrockModel, lambda **kw: RosenbrockModel(**kw), id="RosenbrockModel"),
     pytest.param(AckleyModel, lambda **kw: AckleyModel(**kw), id="AckleyModel"),
     pytest.param(RastriginModel, lambda **kw: RastriginModel(**kw), id="RastriginModel"),
+    pytest.param(
+        HimmelblauModel, lambda **kw: HimmelblauModel(**kw), id="HimmelblauModel"
+    ),
+    pytest.param(BoothModel, lambda **kw: BoothModel(**kw), id="BoothModel"),
+    pytest.param(
+        StyblinskiTangModel,
+        lambda **kw: StyblinskiTangModel(**kw),
+        id="StyblinskiTangModel",
+    ),
     pytest.param(
         InteractionModel,
         lambda **kw: InteractionModel(_Potential(), sigma_w=4.0, strength=0.1, **kw),

--- a/torchebm/core/__init__.py
+++ b/torchebm/core/__init__.py
@@ -6,12 +6,15 @@ from .base_module import TorchEBMModule, warn_once
 
 from .base_model import (
     BaseModel,
+    BoothModel,
     DoubleWellModel,
     GaussianModel,
     HarmonicModel,
+    HimmelblauModel,
     RastriginModel,
     AckleyModel,
     RosenbrockModel,
+    StyblinskiTangModel,
 )
 
 from .base_scheduler import (
@@ -49,13 +52,16 @@ __all__ = [
     # Energy functions
     "TorchEBMModule",
     "warn_once",
+    "BoothModel",
     "BaseModel",
     "DoubleWellModel",
     "GaussianModel",
     "HarmonicModel",
+    "HimmelblauModel",
     "RastriginModel",
     "AckleyModel",
     "RosenbrockModel",
+    "StyblinskiTangModel",
     # Base classes and utilities
     "BaseSampler",
     "BaseLoss",

--- a/torchebm/core/base_model.py
+++ b/torchebm/core/base_model.py
@@ -326,3 +326,46 @@ class RastriginModel(BaseModel):
         return self.a * n + torch.sum(
             x**2 - self.a * torch.cos(2 * math.pi * x), dim=-1
         )
+
+
+class HimmelblauModel(BaseModel):
+    r"""Energy-based model for the two-dimensional Himmelblau function."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        r"""Computes \((x_1^2 + x_2 - 11)^2 + (x_1 + x_2^2 - 7)^2\)."""
+        if x.ndim == 1:
+            x = x.unsqueeze(0)
+        if x.shape[-1] != 2:
+            raise ValueError(
+                f"Himmelblau energy function requires 2 dimensions, got {x.shape[-1]}"
+            )
+
+        x1, x2 = x.unbind(dim=-1)
+        return (x1.pow(2) + x2 - 11).pow(2) + (x1 + x2.pow(2) - 7).pow(2)
+
+
+class BoothModel(BaseModel):
+    r"""Energy-based model for the two-dimensional Booth function."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        r"""Computes \((x_1 + 2x_2 - 7)^2 + (2x_1 + x_2 - 5)^2\)."""
+        if x.ndim == 1:
+            x = x.unsqueeze(0)
+        if x.shape[-1] != 2:
+            raise ValueError(
+                f"Booth energy function requires 2 dimensions, got {x.shape[-1]}"
+            )
+
+        x1, x2 = x.unbind(dim=-1)
+        return (x1 + 2 * x2 - 7).pow(2) + (2 * x1 + x2 - 5).pow(2)
+
+
+class StyblinskiTangModel(BaseModel):
+    r"""Energy-based model for the Styblinski-Tang function."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        r"""Computes \(\frac{1}{2}\sum_i(x_i^4 - 16x_i^2 + 5x_i)\)."""
+        if x.ndim == 1:
+            x = x.unsqueeze(0)
+
+        return 0.5 * (x.pow(4) - 16 * x.pow(2) + 5 * x).sum(dim=-1)


### PR DESCRIPTION
## Summary

- add vectorized Himmelblau and Booth two-dimensional energy models
- add a dimension-agnostic Styblinski-Tang energy model
- export all three models through `torchebm.core`
- cover batched values, dimensional validation, closed-form gradients, and constructor errors

## Validation

- `pytest tests/core/test_base_model.py tests/models/test_constructor_kwargs.py -q` (42 passed)
- `pytest tests/ -q` (passed, 2 skipped)
- `black --check` on all four changed files
- `isort --check-only` on the changed implementation and test files; `torchebm/core/__init__.py` retains its intentional initialization order to avoid circular imports

Closes #189