### PR TITLE
perf(models): cache MLPTimestepEmbedder frequency table as a non-persistent buffer

### DIFF
--- a/tests/models/components/test_embeddings.py
+++ b/tests/models/components/test_embeddings.py
@@ -1,7 +1,68 @@
+import math
+
 import pytest
 import torch
 
 from torchebm.models.components.embeddings import LabelEmbedder, MLPTimestepEmbedder
+
+
+def _reference_freq_embedding(t, dim, max_period=10000):
+    """Straightforward per-call computation used before the buffer was cached."""
+    half = dim // 2
+    freqs = torch.exp(
+        -math.log(max_period)
+        * torch.arange(start=0, end=half, device=t.device, dtype=torch.float32)
+        / half
+    )
+    args = t[:, None].float() * freqs[None]
+    emb = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+    if dim % 2:
+        emb = torch.cat([emb, torch.zeros_like(emb[:, :1])], dim=-1)
+    return emb
+
+
+@pytest.mark.parametrize("freq_dim", [16, 128, 7])
+def test_mlp_timestep_embedder_freq_buffer_matches_recompute(freq_dim):
+    """The cached freq table must produce output identical to recomputing it."""
+    torch.manual_seed(0)
+    emb = MLPTimestepEmbedder(out_dim=32, frequency_embedding_size=freq_dim)
+    t = torch.linspace(0.0, 999.0, steps=8)
+
+    expected = emb.mlp(_reference_freq_embedding(t, freq_dim))
+    got = emb(t)
+    assert torch.allclose(got, expected, rtol=0, atol=0)
+
+
+def test_mlp_timestep_embedder_registers_nonpersistent_freq_buffer():
+    emb = MLPTimestepEmbedder(out_dim=16, frequency_embedding_size=32)
+    # Buffer is registered and enumerated by .buffers()/.named_buffers().
+    assert "freqs" in dict(emb.named_buffers())
+    assert any(b is emb.freqs for b in emb.buffers())
+    # Non-persistent: excluded from the state dict so checkpoints stay clean.
+    assert "freqs" not in emb.state_dict()
+    # Expected precomputed values.
+    expected = torch.exp(
+        -math.log(10000) * torch.arange(0, 16, dtype=torch.float32) / 16
+    )
+    assert torch.equal(emb.freqs, expected)
+
+
+def test_mlp_timestep_embedder_freq_buffer_is_not_reallocated_per_call():
+    emb = MLPTimestepEmbedder(out_dim=16, frequency_embedding_size=32)
+    freq_id = id(emb.freqs)
+    emb(torch.rand(4))
+    emb(torch.rand(6))
+    assert id(emb.freqs) == freq_id
+
+
+def test_mlp_timestep_embedder_freq_buffer_moves_with_module():
+    emb = MLPTimestepEmbedder(out_dim=16, frequency_embedding_size=32)
+    # .to(dtype) moves the buffer just like parameters.
+    emb64 = emb.to(torch.float64)
+    assert emb64.freqs.dtype == torch.float64
+    if torch.cuda.is_available():
+        emb_cuda = MLPTimestepEmbedder(out_dim=16).cuda()
+        assert emb_cuda.freqs.is_cuda
 
 
 @pytest.mark.parametrize("out_dim", [32, 64])

--- a/torchebm/models/components/embeddings.py
+++ b/torchebm/models/components/embeddings.py
@@ -13,14 +13,31 @@ class MLPTimestepEmbedder(nn.Module):
     This is a generic block (useful for EqM, diffusion, flows, etc.).
     """
 
-    def __init__(self, out_dim: int, frequency_embedding_size: int = 256):
+    def __init__(
+        self,
+        out_dim: int,
+        frequency_embedding_size: int = 256,
+        max_period: int = 10000,
+    ):
         super().__init__()
         self.frequency_embedding_size = int(frequency_embedding_size)
+        self.max_period = int(max_period)
         self.mlp = nn.Sequential(
             nn.Linear(self.frequency_embedding_size, out_dim, bias=True),
             nn.SiLU(),
             nn.Linear(out_dim, out_dim, bias=True),
         )
+        # Precompute the sinusoidal frequency table once and cache it as a
+        # non-persistent buffer. It is deterministic given the config, so it
+        # never needs to be recomputed per forward pass and moves with the
+        # module across devices/dtypes via ``.to()``/``.cuda()``.
+        half = self.frequency_embedding_size // 2
+        freqs = torch.exp(
+            -math.log(self.max_period)
+            * torch.arange(start=0, end=half, dtype=torch.float32)
+            / half
+        )
+        self.register_buffer("freqs", freqs, persistent=False)
 
     @staticmethod
     def sinusoidal_embedding(t: torch.Tensor, dim: int, max_period: int = 10000) -> torch.Tensor:
@@ -40,8 +57,12 @@ class MLPTimestepEmbedder(nn.Module):
     def forward(self, t: torch.Tensor) -> torch.Tensor:
         if t.ndim != 1:
             t = t.reshape(t.shape[0])
-        freq = self.sinusoidal_embedding(t, self.frequency_embedding_size)
-        return self.mlp(freq)
+        # Reuse the cached frequency table instead of rebuilding it each call.
+        args = t[:, None].float() * self.freqs[None]
+        emb = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        if self.frequency_embedding_size % 2:
+            emb = torch.cat([emb, torch.zeros_like(emb[:, :1])], dim=-1)
+        return self.mlp(emb)
 
 
 class LabelEmbedder(nn.Module):


### PR DESCRIPTION
Closes #307

## What
`MLPTimestepEmbedder` rebuilt its sinusoidal frequency table (`exp(arange(...) * ...)`) on every `forward` call. The table is fully determined by the module config, so this recomputed identical values each step — and on CUDA it allocated the `arange` on the input device every call, adding host→device work per step.

This precomputes the table once in `__init__` and registers it via `register_buffer("freqs", ..., persistent=False)`, then reuses it in `forward`. The buffer moves with `.to()`/`.cuda()` automatically and, being non-persistent, stays out of `state_dict()` so checkpoints are unaffected.

The public static `sinusoidal_embedding` helper is left unchanged. A `max_period` constructor argument (default `10000`, the previous constant) is exposed so the cached period is configurable; default behavior is identical.

## Behavior
Bit-exact: output matches the previous per-call computation (`torch.allclose(..., rtol=0, atol=0)`).

## How tested
- Exact equality vs. the previous recompute path (freq dims 16, 128, odd 7)
- Buffer registered, enumerated by `buffers()`, excluded from `state_dict`
- Buffer not reallocated across calls (stable id); follows the module under `.to(dtype)`
- Existing `test_timestep_embedding_bitwise_matches_reference` still passes
- Full `tests/models/` suite: 180 passed