### PR TITLE
docs: eliminate Griffe API warnings

### DIFF
--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -90,7 +90,7 @@ jobs:
           cat mkdocs.yml | grep -E "site_dir|docs_dir" || echo "No site_dir or docs_dir specified in mkdocs.yml"
           
           # First build the documentation to generate the site directory
-          mkdocs build -v
+          mkdocs build -v --strict
           
           # Check the output directory after build
           echo "Directories after build:"

--- a/torchebm/core/base_integrator.py
+++ b/torchebm/core/base_integrator.py
@@ -59,8 +59,8 @@ class BaseIntegrator(TorchEBMModule, ABC):
         Args:
             state: Mapping containing required tensors (e.g., {'x': ..., 'p': ...}).
             step_size: Step size for the integration.
-            *args: Additional positional arguments specific to the integrator.
-            **kwargs: Additional keyword arguments specific to the integrator.
+            *args (Any): Additional positional arguments specific to the integrator.
+            **kwargs (Any): Additional keyword arguments specific to the integrator.
 
         Returns:
             Updated state dict with the same keys as the input `state`.
@@ -83,8 +83,8 @@ class BaseIntegrator(TorchEBMModule, ABC):
             state: Mapping containing required tensors (e.g., {'x': ..., 'p': ...}).
             step_size: Step size for the integration.
             n_steps: The number of integration steps to perform.
-            *args: Additional positional arguments specific to the integrator.
-            **kwargs: Additional keyword arguments specific to the integrator.
+            *args (Any): Additional positional arguments specific to the integrator.
+            **kwargs (Any): Additional keyword arguments specific to the integrator.
 
         Returns:
             Updated state dict with the same keys as the input `state`.

--- a/torchebm/core/base_loss.py
+++ b/torchebm/core/base_loss.py
@@ -270,8 +270,8 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
 
         Args:
             x (torch.Tensor): Input data tensor from the target distribution.
-            *args: Additional positional arguments.
-            **kwargs: Additional keyword arguments.
+            *args (Any): Additional positional arguments.
+            **kwargs (Any): Additional keyword arguments.
 
         Returns:
             torch.Tensor: The computed scalar loss value.
@@ -302,10 +302,10 @@ class BaseInterpolantLoss(BaseLoss):
     signature may change as more losses adopt it.
 
     Args:
-        interpolant: Interpolant name (e.g. 'linear', 'cosine', 'vp') or
-            BaseInterpolant instance.
-        coupling: Minibatch coupling name or BaseCoupling instance; ``None``
-            uses the subclass default.
+        interpolant (Union[str, BaseInterpolant]): Interpolant name (e.g.
+            'linear', 'cosine', 'vp') or BaseInterpolant instance.
+        coupling (Optional[Union[str, BaseCoupling]]): Minibatch coupling name
+            or BaseCoupling instance; ``None`` uses the subclass default.
         train_eps: Epsilon for training time interval stability. Float or
             `BaseScheduler`.
         t_sampler: Training-time distribution:
@@ -394,10 +394,10 @@ class BaseInterpolantLoss(BaseLoss):
 
         Args:
             x: Data samples of shape (batch_size, ...).
-            *args: Additional positional arguments.
+            *args (Any): Additional positional arguments.
             x0: Optional source samples of shape (batch_size, ...).
             model_kwargs: Conditioning arguments forwarded to the model.
-            **kwargs: Deprecated bare model kwargs.
+            **kwargs (Any): Deprecated bare model kwargs.
 
         Returns:
             Scalar loss value.
@@ -679,7 +679,7 @@ class BaseContrastiveDivergence(BaseLoss):
         Gets negative samples using the replay buffer strategy.
 
         Args:
-            x: (Unused) The input data tensor.
+            x (torch.Tensor): (Unused) The input data tensor.
             batch_size (int): The number of samples to generate.
             data_shape (Tuple[int, ...]): The shape of the data samples (excluding batch size).
             generator: RNG for the noise and buffer index draws; the global RNG
@@ -848,8 +848,8 @@ class BaseContrastiveDivergence(BaseLoss):
         Args:
             x (torch.Tensor): Real data samples (positive samples).
             pred_x (torch.Tensor): Generated negative samples.
-            *args: Additional positional arguments.
-            **kwargs: Additional keyword arguments.
+            *args (Any): Additional positional arguments.
+            **kwargs (Any): Additional keyword arguments.
 
         Returns:
             torch.Tensor: The contrastive divergence loss.
@@ -1168,8 +1168,8 @@ class BaseScoreMatching(BaseLoss):
 
         Args:
             x (torch.Tensor): Input data tensor.
-            *args: Additional positional arguments.
-            **kwargs: Additional keyword arguments.
+            *args (Any): Additional positional arguments.
+            **kwargs (Any): Additional keyword arguments.
 
         Returns:
             torch.Tensor: The computed score matching loss.
@@ -1183,8 +1183,8 @@ class BaseScoreMatching(BaseLoss):
 
         Args:
             x (torch.Tensor): Input data tensor.
-            *args: Additional positional arguments.
-            **kwargs: Additional keyword arguments.
+            *args (Any): Additional positional arguments.
+            **kwargs (Any): Additional keyword arguments.
 
         Returns:
             torch.Tensor: The specific score matching loss.

--- a/torchebm/core/base_module.py
+++ b/torchebm/core/base_module.py
@@ -68,22 +68,23 @@ def _unexpected_init_args_message(cls, args, kwargs, stop_at: type) -> str:
     )
 
 
-def substitute_condition(y, mask, null):
+def substitute_condition(y, mask, null) -> torch.Tensor:
     r"""Replace conditioning rows selected by `mask` with the null condition.
 
     Shared semantics for classifier-free-guidance label dropout (losses) and
     the guidance wrapper's unconditional half (sampling).
 
     Args:
-        y: Conditioning tensor of shape (batch_size, ...).
-        mask: Bool tensor of shape (batch_size,); True rows become null.
-        null: Null condition: an int/float filled into y's dtype (the
-            ``num_classes`` label convention), a tensor broadcast over y's
-            non-batch dims (e.g. a zero or learned null embedding), or a
-            callable ``(y, mask) -> y``.
+        y (torch.Tensor): Conditioning tensor of shape (batch_size, ...).
+        mask (torch.Tensor): Bool tensor of shape (batch_size,); True rows become
+            null.
+        null (Union[int, float, torch.Tensor, Callable]): Null condition: an
+            int/float filled into y's dtype (the ``num_classes`` label
+            convention), a tensor broadcast over y's non-batch dims (e.g. a
+            zero or learned null embedding), or a callable ``(y, mask) -> y``.
 
     Returns:
-        Tensor of y's shape with masked rows nulled.
+        torch.Tensor: Tensor of y's shape with masked rows nulled.
     """
     if callable(null):
         return null(y, mask)

--- a/torchebm/couplings/ot.py
+++ b/torchebm/couplings/ot.py
@@ -271,13 +271,14 @@ class SinkhornCoupling(BaseCostCoupling):
     Args:
         reg: Entropic regularization strength.
         n_iters: Number of Sinkhorn iterations.
-        process_group: When set, couple globally over the pooled batches of
-            every rank in the group: both batches are all_gathered, every
-            rank solves the identical pooled problem, the row-conditional
-            draw is broadcast from rank 0 (per-rank generators cannot
-            desynchronize it), and each rank keeps its own rows, paired
-            against targets from any rank. This shrinks the minibatch-OT
-            bias at fixed per-rank batch size, at the price of a
+        process_group (Optional[torch.distributed.ProcessGroup]): When set,
+            couple globally over the pooled batches of every rank in the
+            group: both batches are all_gathered, every rank solves the
+            identical pooled problem, the row-conditional draw is broadcast
+            from rank 0 (per-rank generators cannot desynchronize it), and
+            each rank keeps its own rows, paired against targets from any
+            rank. This shrinks the minibatch-OT bias at fixed per-rank batch
+            size, at the price of a
             \((\text{world\_size} \times \text{batch})^2\) cost matrix
             materialized on every rank. Requires equal batch sizes per rank,
             and `couple` becomes a collective every rank must enter

--- a/torchebm/losses/contrastive_divergence.py
+++ b/torchebm/losses/contrastive_divergence.py
@@ -34,16 +34,20 @@ class ContrastiveDivergence(BaseContrastiveDivergence):
     for `k_steps` to generate negative samples.
 
     Args:
-        model: The energy-based model to train.
-        sampler: The MCMC sampler for generating negative samples.
-        k_steps: The number of MCMC steps (k in CD-k).
-        persistent: If True, uses Persistent CD with a replay buffer.
-        buffer_size: Size of the replay buffer for PCD.
-        init_steps: Number of MCMC steps to warm up the buffer.
-        new_sample_ratio: Fraction of new random samples for PCD chains.
-        energy_reg_weight: Weight for energy regularization term.
-        dtype: Data type for computations.
-        device: Device for computations.
+        model (nn.Module): The energy-based model to train.
+        sampler (BaseSampler): The MCMC sampler for generating negative samples.
+        k_steps (int): The number of MCMC steps (k in CD-k).
+        persistent (bool): If True, uses Persistent CD with a replay buffer.
+        buffer_size (int): Size of the replay buffer for PCD.
+        init_steps (int): Number of MCMC steps to warm up the buffer.
+        new_sample_ratio (float): Fraction of new random samples for PCD chains.
+        energy_reg_weight (float): Weight for energy regularization term.
+        add_noise_to_real (bool): Whether to perturb positive samples before
+            evaluating their energy.
+        noise_scale (float): Standard deviation of the optional positive-sample
+            perturbation.
+        dtype (torch.dtype): Data type for computations.
+        device (Union[str, torch.device]): Device for computations.
 
     Example:
         ```python
@@ -109,7 +113,7 @@ class ContrastiveDivergence(BaseContrastiveDivergence):
 
         Args:
             x (torch.Tensor): A batch of real data samples (positive samples).
-            *args: Additional positional arguments.
+            *args (Any): Additional positional arguments.
             y (Optional[torch.Tensor]): Optional conditioning tensor forwarded
                 to the model on both positive and negative paths; shorthand for
                 ``model_kwargs={'y': y}``.
@@ -121,7 +125,7 @@ class ContrastiveDivergence(BaseContrastiveDivergence):
                 optional real-data noise; the global RNG when ``None``. In
                 distributed runs, a per-rank generator keeps the negative chains
                 of each rank independent.
-            **kwargs: Deprecated. The loss options ``energy_reg_weight``,
+            **kwargs (Any): Deprecated. The loss options ``energy_reg_weight``,
                 ``add_noise_to_real`` and ``noise_scale`` are now constructor
                 parameters; passing them here still works for one release but
                 emits a ``DeprecationWarning``.
@@ -191,10 +195,10 @@ class ContrastiveDivergence(BaseContrastiveDivergence):
         Args:
             x (torch.Tensor): Real data samples (positive samples).
             pred_x (torch.Tensor): Generated negative samples.
-            *args: Additional positional arguments.
+            *args (Any): Additional positional arguments.
             generator: RNG for the optional real-data noise; the global RNG
                 when `None`.
-            **kwargs: Additional keyword arguments.
+            **kwargs (Any): Additional keyword arguments.
 
         Returns:
             torch.Tensor: The scalar loss value.

--- a/torchebm/losses/energy_matching.py
+++ b/torchebm/losses/energy_matching.py
@@ -264,7 +264,7 @@ class EnergyMatchingLoss(BaseInterpolantLoss):
 
         Args:
             x: Data samples of shape (batch_size, ...).
-            *args: Additional positional arguments.
+            *args (Any): Additional positional arguments.
             y: Optional conditioning tensor forwarded to the potential as
                 ``y=``; shorthand for ``model_kwargs={'y': y}``. ``None`` keeps
                 the unconditional path.
@@ -274,7 +274,7 @@ class EnergyMatchingLoss(BaseInterpolantLoss):
             model_kwargs: Conditioning arguments (e.g. class labels) forwarded to
                 the potential on both the positive and negative (Langevin) paths.
                 ``None`` (default) is the unconditional path.
-            **kwargs: Deprecated. Bare keyword arguments are still forwarded to
+            **kwargs (Any): Deprecated. Bare keyword arguments are still forwarded to
                 the model for one release but emit a ``DeprecationWarning``; pass
                 ``model_kwargs={...}`` instead.
 
@@ -302,10 +302,10 @@ class EnergyMatchingLoss(BaseInterpolantLoss):
 
         Args:
             x: Data samples of shape (batch_size, ...).
-            *args: Additional positional arguments.
+            *args (Any): Additional positional arguments.
             x0: Optional source samples (see `forward`).
             model_kwargs: Conditioning arguments forwarded to the potential.
-            **kwargs: Deprecated bare model kwargs (see `forward`).
+            **kwargs (Any): Deprecated bare model kwargs (see `forward`).
 
         Returns:
             Scalar loss value.

--- a/torchebm/losses/equilibrium_matching.py
+++ b/torchebm/losses/equilibrium_matching.py
@@ -318,7 +318,7 @@ class EquilibriumMatchingLoss(BaseInterpolantLoss):
 
         Args:
             x: Data samples of shape (batch_size, ...).
-            *args: Additional positional arguments.
+            *args (Any): Additional positional arguments.
             y: Optional conditioning tensor (class labels, embeddings, ...)
                 forwarded to the model as ``model(x, t, y=y)``; shorthand for
                 ``model_kwargs={'y': y}``. ``None`` keeps the unconditional path.
@@ -327,7 +327,7 @@ class EquilibriumMatchingLoss(BaseInterpolantLoss):
                 distribution for arbitrary source-to-target transport.
             model_kwargs: Conditioning arguments (e.g. class labels) forwarded to
                 the model. ``None`` (default) is the unconditional path.
-            **kwargs: Deprecated. Bare keyword arguments are still forwarded to
+            **kwargs (Any): Deprecated. Bare keyword arguments are still forwarded to
                 the model for one release but emit a ``DeprecationWarning``; pass
                 ``model_kwargs={...}`` instead.
 

--- a/torchebm/losses/flow_matching.py
+++ b/torchebm/losses/flow_matching.py
@@ -127,13 +127,13 @@ class FlowMatchingLoss(BaseInterpolantLoss):
 
         Args:
             x: Data samples of shape (batch_size, ...).
-            *args: Additional positional arguments.
+            *args (Any): Additional positional arguments.
             y: Optional conditioning tensor forwarded to the model; shorthand
                 for ``model_kwargs={'y': y}``.
             x0: Optional source samples of shape (batch_size, ...). Defaults to
                 standard Gaussian noise.
             model_kwargs: Conditioning arguments forwarded to the model.
-            **kwargs: Deprecated bare model kwargs; pass ``model_kwargs={...}``.
+            **kwargs (Any): Deprecated bare model kwargs; pass ``model_kwargs={...}``.
 
         Returns:
             Scalar loss value.

--- a/torchebm/losses/score_matching.py
+++ b/torchebm/losses/score_matching.py
@@ -91,13 +91,13 @@ class ScoreMatching(BaseScoreMatching):
 
         Args:
             x (torch.Tensor): Input data tensor of shape `(batch_size, *data_dims)`.
-            *args: Additional positional arguments.
+            *args (Any): Additional positional arguments.
             y: Optional conditioning tensor; shorthand for
                 ``model_kwargs={'y': y}`` with the same support constraints.
             model_kwargs: Conditioning arguments (e.g. class labels) forwarded to
                 the model. Supported for ``hessian_method="approx"``; the exact
                 Hessian path raises if conditioning is passed (see below).
-            **kwargs: Deprecated bare model kwargs.
+            **kwargs (Any): Deprecated bare model kwargs.
 
         Returns:
             torch.Tensor: The scalar score matching loss.
@@ -130,10 +130,10 @@ class ScoreMatching(BaseScoreMatching):
 
         Args:
             x (torch.Tensor): Input data tensor of shape `(batch_size, *data_dims)`.
-            *args: Additional arguments.
+            *args (Any): Additional arguments.
             model_kwargs: Conditioning arguments forwarded to the model
                 (``hessian_method="approx"`` only).
-            **kwargs: Deprecated bare model kwargs.
+            **kwargs (Any): Deprecated bare model kwargs.
 
         Returns:
             torch.Tensor: The scalar score matching loss.
@@ -310,12 +310,12 @@ class DenoisingScoreMatching(BaseScoreMatching):
 
         Args:
             x (torch.Tensor): Input data tensor of shape `(batch_size, *data_dims)`.
-            *args: Additional positional arguments.
+            *args (Any): Additional positional arguments.
             y: Optional conditioning tensor forwarded to the model; shorthand
                 for ``model_kwargs={'y': y}``.
             model_kwargs: Conditioning arguments (e.g. class labels) forwarded to
                 the model. ``None`` (default) is the unconditional path.
-            **kwargs: Deprecated bare model kwargs (see `model_kwargs`).
+            **kwargs (Any): Deprecated bare model kwargs (see `model_kwargs`).
 
         Returns:
             torch.Tensor: The scalar denoising score matching loss.
@@ -348,9 +348,9 @@ class DenoisingScoreMatching(BaseScoreMatching):
 
         Args:
             x (torch.Tensor): Input data tensor of shape `(batch_size, *data_dims)`.
-            *args: Additional arguments.
+            *args (Any): Additional arguments.
             model_kwargs: Conditioning arguments forwarded to the model.
-            **kwargs: Deprecated bare model kwargs.
+            **kwargs (Any): Deprecated bare model kwargs.
 
         Returns:
             torch.Tensor: The scalar denoising score matching loss.
@@ -480,14 +480,14 @@ class SlicedScoreMatching(BaseScoreMatching):
 
         Args:
             x (torch.Tensor): Input data tensor of shape `(batch_size, *data_dims)`.
-            *args: Additional positional arguments.
+            *args (Any): Additional positional arguments.
             y: Optional conditioning tensor; conditioning is not supported here,
                 so any non-None value raises in `compute_loss` (see
                 `model_kwargs`).
             model_kwargs: Conditioning is not supported (the projection tiling
                 expands the batch, so per-sample conditioning cannot be aligned);
                 a non-empty mapping raises in `compute_loss`.
-            **kwargs: Deprecated bare model kwargs.
+            **kwargs (Any): Deprecated bare model kwargs.
 
         Returns:
             torch.Tensor: The scalar sliced score matching loss.
@@ -519,9 +519,9 @@ class SlicedScoreMatching(BaseScoreMatching):
 
         Args:
             x (torch.Tensor): Input data tensor of shape `(batch_size, *data_dims)`.
-            *args: Additional arguments.
+            *args (Any): Additional arguments.
             model_kwargs: Not supported; a non-empty mapping raises.
-            **kwargs: Deprecated bare model kwargs.
+            **kwargs (Any): Deprecated bare model kwargs.
 
         Returns:
             torch.Tensor: The scalar sliced score matching loss.
@@ -602,5 +602,3 @@ class SlicedScoreMatching(BaseScoreMatching):
         term1 = (0.5 * v_score.square()).view(self.n_projections, -1).mean(dim=0)
         term2 = term2.view(self.n_projections, -1).mean(dim=0)
         return (term1 + term2).mean()
-
-    

--- a/torchebm/samplers/flow.py
+++ b/torchebm/samplers/flow.py
@@ -440,7 +440,7 @@ class FlowSampler(BaseSampler):
             generator: RNG for the initial state and, in SDE mode, the per-step
                 diffusion noise; the global RNG when ``None``. ODE mode is
                 deterministic once the initial state is fixed.
-            **legacy_model_kwargs: Deprecated. Passing conditioning as bare
+            **legacy_model_kwargs (Any): Deprecated. Passing conditioning as bare
                 keyword arguments still works for one release but emits a
                 ``DeprecationWarning``; pass ``model_kwargs={...}`` instead. When
                 both are given, keys in the explicit dict win.

--- a/torchebm/utils/profiling.py
+++ b/torchebm/utils/profiling.py
@@ -20,6 +20,7 @@ Example:
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Optional, Sequence
 
@@ -44,7 +45,7 @@ def profile_context(
     row_limit: int = 20,
     export_trace: Optional[str] = None,
     print_table: bool = True,
-):
+) -> Iterator[profile]:
     r"""Context manager for profiling TorchEBM operations.
 
     Wraps ``torch.profiler.profile`` with automatic CUDA sync, table printing,
@@ -63,7 +64,7 @@ def profile_context(
         print_table: Whether to print the summary table on exit.
 
     Yields:
-        ``torch.profiler.profile`` instance for advanced access.
+        torch.profiler.profile: Profiler instance for advanced access.
     """
     if activities is None:
         activities = _default_activities()


### PR DESCRIPTION
Closes #186.

## Summary

- add explicit Google-style types for every unannotated API parameter that Griffe reported;
- annotate the conditioning helper return and profiling context yield so generated API docs can infer them;
- run the documentation build in strict mode to prevent warning regressions.

The current `master` build emitted 58 Griffe warnings across core, couplings, losses, samplers, and utilities. The same build now completes without Griffe warnings.

## Verification

- `DISABLE_MKDOCS_2_WARNING=true mkdocs build -v --strict`
- `pytest`: 1,853 passed, 2 skipped, 21 deselected
- workflow YAML parsed with PyYAML
- `git diff --check`