### PR TITLE
Fix unusable contrastive divergence exports

### DIFF
--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -120,6 +120,12 @@ COMPONENT_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "returns_tuple": True,
         "init_kwargs": {"k_steps": 10, "persistent": False},
     },
+    "PersistentContrastiveDivergence": {
+        "model_type": "ebm",
+        "needs_sampler": True,
+        "returns_tuple": True,
+        "init_kwargs": {"k_steps": 10},
+    },
     "EquilibriumMatchingLoss": {
         "model_type": "velocity",
         "init_kwargs": {
@@ -138,9 +144,6 @@ COMPONENT_OVERRIDES: Dict[str, Dict[str, Any]] = {
         # the expensive Langevin negative-sampling chains.
         "init_kwargs": {"lambda_cd": 0.0},
     },
-    # Stubs — skip
-    "PersistentContrastiveDivergence": {"skip": True},
-    "ParallelTemperingCD": {"skip": True},
     # ── Samplers ──
     "LangevinDynamics": {
         "model_type": "ebm_double_well",

--- a/docs/concepts/objectives.md
+++ b/docs/concepts/objectives.md
@@ -34,10 +34,8 @@ loss, negatives = cd(batch)
 
 `persistent=True` switches to PCD: negatives resume from a replay buffer
 instead of restarting at the data, so chains explore the model distribution
-across updates. `ParallelTemperingCD` runs chains at several temperatures and
-swaps them, for multimodal targets where single-temperature chains get stuck.
-CD trains slowly per step (an inner MCMC loop) but yields a genuine energy
-with meaningful level sets.
+across updates. CD trains slowly per step (an inner MCMC loop) but yields a
+genuine energy with meaningful level sets.
 
 ## Simulation-free: score matching
 

--- a/tests/losses/test_contrastive_divergence.py
+++ b/tests/losses/test_contrastive_divergence.py
@@ -9,7 +9,6 @@ from torchebm.samplers import LangevinDynamics
 from torchebm.losses import (
     ContrastiveDivergence,
     PersistentContrastiveDivergence,
-    ParallelTemperingCD,
 )
 from tests.conftest import requires_cuda
 
@@ -277,6 +276,28 @@ def test_contrastive_divergence_initialization(energy_function, sampler, device)
     assert cd.energy_reg_weight == 0.002
     assert cd.device == device
     assert cd.replay_buffer is None
+
+
+def test_persistent_contrastive_divergence_runs_training_step(energy_function, sampler):
+    device = sampler.device
+    energy_function = energy_function.to(device)
+    cd = PersistentContrastiveDivergence(
+        model=energy_function,
+        sampler=sampler,
+        k_steps=2,
+        buffer_size=20,
+        init_steps=2,
+        device=device,
+    )
+    x = torch.randn(5, 2, device=device)
+
+    loss, samples = cd(x)
+
+    assert cd.persistent is True
+    assert cd.buffer_initialized is True
+    assert cd.replay_buffer.shape == (20, 2)
+    assert loss.shape == torch.Size([])
+    assert samples.shape == x.shape
 
 
 def test_contrastive_divergence_forward(cd_loss):

--- a/tests/losses/test_public_api.py
+++ b/tests/losses/test_public_api.py
@@ -1,0 +1,31 @@
+import inspect
+
+import torch
+
+import torchebm.losses as losses
+from torchebm.core import GaussianModel
+from torchebm.samplers import LangevinDynamics
+
+
+def test_all_public_loss_classes_can_be_constructed():
+    model = GaussianModel(mean=torch.zeros(2), cov=torch.eye(2))
+    sampler = LangevinDynamics(model=model)
+    constructors = {
+        "ContrastiveDivergence": lambda: losses.ContrastiveDivergence(model, sampler),
+        "PersistentContrastiveDivergence": lambda: (
+            losses.PersistentContrastiveDivergence(model, sampler)
+        ),
+        "ScoreMatching": lambda: losses.ScoreMatching(model),
+        "DenoisingScoreMatching": lambda: losses.DenoisingScoreMatching(model),
+        "SlicedScoreMatching": lambda: losses.SlicedScoreMatching(model),
+        "EquilibriumMatchingLoss": lambda: losses.EquilibriumMatchingLoss(model),
+        "FlowMatchingLoss": lambda: losses.FlowMatchingLoss(model),
+        "EnergyMatchingLoss": lambda: losses.EnergyMatchingLoss(model),
+    }
+    public_classes = {
+        name for name in losses.__all__ if inspect.isclass(getattr(losses, name))
+    }
+
+    assert constructors.keys() == public_classes
+    for name, constructor in constructors.items():
+        assert type(constructor()).__name__ == name

--- a/torchebm/losses/__init__.py
+++ b/torchebm/losses/__init__.py
@@ -6,7 +6,6 @@ __all__ = [
     # Contrastive Divergence
     "ContrastiveDivergence",
     "PersistentContrastiveDivergence",
-    "ParallelTemperingCD",
     # Score Matching
     "ScoreMatching",
     "DenoisingScoreMatching",
@@ -29,7 +28,6 @@ __all__ = [
 _LAZY_IMPORTS = {
     "ContrastiveDivergence": ".contrastive_divergence",
     "PersistentContrastiveDivergence": ".contrastive_divergence",
-    "ParallelTemperingCD": ".contrastive_divergence",
     "ScoreMatching": ".score_matching",
     "DenoisingScoreMatching": ".score_matching",
     "SlicedScoreMatching": ".score_matching",

--- a/torchebm/losses/contrastive_divergence.py
+++ b/torchebm/losses/contrastive_divergence.py
@@ -242,41 +242,9 @@ class ContrastiveDivergence(BaseContrastiveDivergence):
         return loss
 
 
-class PersistentContrastiveDivergence(BaseContrastiveDivergence):
-    def __init__(self, buffer_size=100):
-        super().__init__(k_steps=1)
-        self.buffer = None  # Persistent chain state
-        self.buffer_size = buffer_size
+class PersistentContrastiveDivergence(ContrastiveDivergence):
+    """Contrastive divergence with replay-buffer persistence enabled."""
 
-    # def sample(self, energy_model, x_pos):
-    #     if self.buffer is None or len(self.buffer) != self.buffer_size:
-    #         # Initialize buffer with random noise
-    #         self.buffer = torch.randn(self.buffer_size, *x_pos.batch_shape[1:],
-    #                                   device=x_pos.device)
-    #
-    #     # Update buffer with Gibbs steps
-    #     for _ in range(self.k_steps):
-    #         self.buffer = energy_model.gibbs_step(self.buffer)
-    #
-    #     # Return a subset of the buffer as negative samples
-    #     idx = torch.randint(0, self.buffer_size, (x_pos.batch_shape[0],))
-    #     return self.buffer[idx]
-
-
-class ParallelTemperingCD(BaseContrastiveDivergence):
-    def __init__(self, temps=[1.0, 0.5], k=5):
-        super().__init__(k)
-        self.temps = temps  # List of temperatures
-
-    # def sample(self, energy_model, x_pos):
-    #     chains = [x_pos.detach().clone() for _ in self.temps]
-    #     for _ in range(self.k_steps):
-    #         # Run Gibbs steps at each temperature
-    #         for i, temp in enumerate(self.temps):
-    #             chains[i] = energy_model.gibbs_step(chains[i], temp=temp)
-    #
-    #         # Swap states between chains (temperature exchange)
-    #         swap_idx = torch.randint(0, len(self.temps) - 1, (1,))
-    #         chains[swap_idx], chains[swap_idx + 1] = chains[swap_idx + 1], chains[swap_idx]
-    #
-    #     return chains[0]  # Return samples from the highest-temperature chain
+    def __init__(self, model, sampler, *args, **kwargs):
+        kwargs["persistent"] = True
+        super().__init__(model, sampler, *args, **kwargs)


### PR DESCRIPTION
`PersistentContrastiveDivergence` was publicly exported but could not be instantiated, while `ParallelTemperingCD` exposed a commented-out draft as part of the public API.

This makes the persistent variant a thin subclass of the working `ContrastiveDivergence` implementation with persistence pinned on. It also removes the unfinished parallel-tempering class from the module, lazy exports, benchmark registry, and user documentation. A public API contract test now constructs every exported loss class, and the persistent variant is covered by an actual training step and benchmark construction.

Closes #321.
Closes #322.

Validation:
- `pytest tests/losses/test_public_api.py tests/losses/test_contrastive_divergence.py -q`
- `pytest tests/ -q`
- CPU construction and execution through `benchmarks.registry.build_loss_bench`
