### PR TITLE
Remove ParallelTemperingCD

### DIFF
--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -140,7 +140,6 @@ COMPONENT_OVERRIDES: Dict[str, Dict[str, Any]] = {
     },
     # Stubs — skip
     "PersistentContrastiveDivergence": {"skip": True},
-    "ParallelTemperingCD": {"skip": True},
     # ── Samplers ──
     "LangevinDynamics": {
         "model_type": "ebm_double_well",

--- a/docs/concepts/objectives.md
+++ b/docs/concepts/objectives.md
@@ -34,8 +34,7 @@ loss, negatives = cd(batch)
 
 `persistent=True` switches to PCD: negatives resume from a replay buffer
 instead of restarting at the data, so chains explore the model distribution
-across updates. `ParallelTemperingCD` runs chains at several temperatures and
-swaps them, for multimodal targets where single-temperature chains get stuck.
+across updates.
 CD trains slowly per step (an inner MCMC loop) but yields a genuine energy
 with meaningful level sets.
 

--- a/tests/losses/test_contrastive_divergence.py
+++ b/tests/losses/test_contrastive_divergence.py
@@ -1,4 +1,12 @@
 import pytest
+
+def test_parallel_tempering_cd_removed():
+    import torchebm.losses as losses
+
+    assert "ParallelTemperingCD" not in losses.__all__
+
+    with pytest.raises(AttributeError):
+        losses.ParallelTemperingCD
 import torch
 import torch.nn as nn
 import numpy as np
@@ -9,7 +17,6 @@ from torchebm.samplers import LangevinDynamics
 from torchebm.losses import (
     ContrastiveDivergence,
     PersistentContrastiveDivergence,
-    ParallelTemperingCD,
 )
 from tests.conftest import requires_cuda
 

--- a/torchebm/losses/__init__.py
+++ b/torchebm/losses/__init__.py
@@ -6,7 +6,6 @@ __all__ = [
     # Contrastive Divergence
     "ContrastiveDivergence",
     "PersistentContrastiveDivergence",
-    "ParallelTemperingCD",
     # Score Matching
     "ScoreMatching",
     "DenoisingScoreMatching",
@@ -29,7 +28,6 @@ __all__ = [
 _LAZY_IMPORTS = {
     "ContrastiveDivergence": ".contrastive_divergence",
     "PersistentContrastiveDivergence": ".contrastive_divergence",
-    "ParallelTemperingCD": ".contrastive_divergence",
     "ScoreMatching": ".score_matching",
     "DenoisingScoreMatching": ".score_matching",
     "SlicedScoreMatching": ".score_matching",

--- a/torchebm/losses/contrastive_divergence.py
+++ b/torchebm/losses/contrastive_divergence.py
@@ -261,22 +261,3 @@ class PersistentContrastiveDivergence(BaseContrastiveDivergence):
     #     # Return a subset of the buffer as negative samples
     #     idx = torch.randint(0, self.buffer_size, (x_pos.batch_shape[0],))
     #     return self.buffer[idx]
-
-
-class ParallelTemperingCD(BaseContrastiveDivergence):
-    def __init__(self, temps=[1.0, 0.5], k=5):
-        super().__init__(k)
-        self.temps = temps  # List of temperatures
-
-    # def sample(self, energy_model, x_pos):
-    #     chains = [x_pos.detach().clone() for _ in self.temps]
-    #     for _ in range(self.k_steps):
-    #         # Run Gibbs steps at each temperature
-    #         for i, temp in enumerate(self.temps):
-    #             chains[i] = energy_model.gibbs_step(chains[i], temp=temp)
-    #
-    #         # Swap states between chains (temperature exchange)
-    #         swap_idx = torch.randint(0, len(self.temps) - 1, (1,))
-    #         chains[swap_idx], chains[swap_idx + 1] = chains[swap_idx + 1], chains[swap_idx]
-    #
-    #     return chains[0]  # Return samples from the highest-temperature chain


### PR DESCRIPTION
## Summary

- Remove the broken `ParallelTemperingCD` class
- Remove its exports, benchmark entry, and documentation
- Add a regression test confirming it is no longer available

Closes #322

## Tests

- `python -m pytest tests/losses/test_contrastive_divergence.py`
- 18 passed, 9 skipped (CUDA unavailable)