### PR TITLE
feat(samplers): config-revealing reprs, working contrastive divergence exports

### DIFF
--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -120,6 +120,12 @@ COMPONENT_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "returns_tuple": True,
         "init_kwargs": {"k_steps": 10, "persistent": False},
     },
+    "PersistentContrastiveDivergence": {
+        "model_type": "ebm",
+        "needs_sampler": True,
+        "returns_tuple": True,
+        "init_kwargs": {"k_steps": 10},
+    },
     "EquilibriumMatchingLoss": {
         "model_type": "velocity",
         "init_kwargs": {
@@ -138,9 +144,6 @@ COMPONENT_OVERRIDES: Dict[str, Dict[str, Any]] = {
         # the expensive Langevin negative-sampling chains.
         "init_kwargs": {"lambda_cd": 0.0},
     },
-    # Stubs — skip
-    "PersistentContrastiveDivergence": {"skip": True},
-    "ParallelTemperingCD": {"skip": True},
     # ── Samplers ──
     "LangevinDynamics": {
         "model_type": "ebm_double_well",

--- a/docs/concepts/objectives.md
+++ b/docs/concepts/objectives.md
@@ -34,10 +34,8 @@ loss, negatives = cd(batch)
 
 `persistent=True` switches to PCD: negatives resume from a replay buffer
 instead of restarting at the data, so chains explore the model distribution
-across updates. `ParallelTemperingCD` runs chains at several temperatures and
-swaps them, for multimodal targets where single-temperature chains get stuck.
-CD trains slowly per step (an inner MCMC loop) but yields a genuine energy
-with meaningful level sets.
+across updates. CD trains slowly per step (an inner MCMC loop) but yields a
+genuine energy with meaningful level sets.
 
 ## Simulation-free: score matching
 

--- a/tests/integrators/test_dopri5.py
+++ b/tests/integrators/test_dopri5.py
@@ -76,6 +76,13 @@ def test_dopri5_custom_tolerances():
     assert integrator.max_factor == 5.0
 
 
+def test_dopri5_repr_shows_tolerances():
+    """Adaptive methods (error_weights defined) surface atol/rtol/max_steps."""
+    integrator = Dopri5Integrator(atol=1e-8, rtol=1e-5, max_steps=5000)
+    text = repr(integrator)
+    assert text == "Dopri5Integrator(atol=1e-08, rtol=1e-05, max_steps=5000)"
+
+
 @requires_cuda
 def test_dopri5_cuda():
     """Test CUDA initialization."""

--- a/tests/integrators/test_rk4.py
+++ b/tests/integrators/test_rk4.py
@@ -56,6 +56,12 @@ def test_rk4_no_adaptive_params():
     assert integrator.fsal is False
 
 
+def test_rk4_repr_has_no_hyperparameters():
+    """Fixed-step methods carry no tunable config, so the repr is bare."""
+    assert repr(RK4Integrator()) == "RK4Integrator()"
+    assert repr(RK438Integrator()) == "RK438Integrator()"
+
+
 @requires_cuda
 def test_rk4_cuda():
     integrator = RK4Integrator(device="cuda", dtype=torch.float32)

--- a/tests/integrators/test_symplectic_base.py
+++ b/tests/integrators/test_symplectic_base.py
@@ -88,6 +88,21 @@ def test_safe_mode_zeroes_nans(integrator):
     assert torch.isfinite(result["p"]).all()
 
 
+def test_leapfrog_repr_has_no_hyperparameters():
+    assert repr(LeapfrogIntegrator(device=device)) == "LeapfrogIntegrator()"
+
+
+def test_generalised_leapfrog_repr_shows_solver_hyperparameters():
+    integ = GeneralisedLeapfrogIntegrator(
+        device=device, solver_max_iter=4, solver_tol=1e-3, solver_check_every=2,
+    )
+    text = repr(integ)
+    assert text.startswith("GeneralisedLeapfrogIntegrator(")
+    assert "solver_max_iter=4" in text
+    assert "solver_tol=0.001" in text
+    assert "solver_check_every=2" in text
+
+
 def test_safe_mode_clamps_extreme_forces():
     integ = LeapfrogIntegrator(device=device)
     state = _make_state()

--- a/tests/losses/test_condition_probe.py
+++ b/tests/losses/test_condition_probe.py
@@ -164,6 +164,22 @@ def test_probe_restores_per_module_training_modes():
     assert not model.linear.training
 
 
+def test_probe_restores_per_module_training_modes_after_error():
+    model = ConsumingField()
+    model.train()
+    model.linear.eval()
+    loss_fn = EquilibriumMatchingLoss(model=model)
+
+    def fail_probe(*args, **kwargs):
+        raise RuntimeError("probe failed")
+
+    loss_fn._probe_forward = fail_probe
+    with pytest.raises(RuntimeError, match="probe failed"):
+        loss_fn._check_condition(torch.randn(8, 4), {"y": _distinct_y()})
+    assert model.training
+    assert not model.linear.training
+
+
 def test_zero_init_output_defers_probe():
     model = ZeroInitField(consumes_y=True)
     loss_fn = FlowMatchingLoss(model=model)

--- a/tests/losses/test_condition_probe.py
+++ b/tests/losses/test_condition_probe.py
@@ -154,12 +154,30 @@ def test_uniform_labels_warn_and_disarm():
     assert torch.isfinite(loss_fn(torch.randn(8, 4), y=_distinct_y()))
 
 
-def test_probe_restores_training_mode():
+def test_probe_restores_each_module_training_mode():
     model = ConsumingField()
     model.train()
+    model.linear.eval()
+    training_flags = {module: module.training for module in model.modules()}
     loss_fn = EquilibriumMatchingLoss(model=model)
     loss_fn(torch.randn(8, 4), y=_distinct_y())
-    assert model.training
+    assert {module: module.training for module in model.modules()} == training_flags
+
+
+def test_probe_restores_each_module_training_mode_after_error():
+    model = ConsumingField()
+    model.train()
+    model.linear.eval()
+    training_flags = {module: module.training for module in model.modules()}
+    loss_fn = EquilibriumMatchingLoss(model=model)
+
+    def fail_probe(*args, **kwargs):
+        raise RuntimeError("probe failed")
+
+    loss_fn._probe_forward = fail_probe
+    with pytest.raises(RuntimeError, match="probe failed"):
+        loss_fn._check_condition(torch.randn(8, 4), {"y": _distinct_y()})
+    assert {module: module.training for module in model.modules()} == training_flags
 
 
 def test_zero_init_output_defers_probe():

--- a/tests/losses/test_contrastive_divergence.py
+++ b/tests/losses/test_contrastive_divergence.py
@@ -9,7 +9,6 @@ from torchebm.samplers import LangevinDynamics
 from torchebm.losses import (
     ContrastiveDivergence,
     PersistentContrastiveDivergence,
-    ParallelTemperingCD,
 )
 from tests.conftest import requires_cuda
 
@@ -277,6 +276,28 @@ def test_contrastive_divergence_initialization(energy_function, sampler, device)
     assert cd.energy_reg_weight == 0.002
     assert cd.device == device
     assert cd.replay_buffer is None
+
+
+def test_persistent_contrastive_divergence_runs_training_step(energy_function, sampler):
+    device = sampler.device
+    energy_function = energy_function.to(device)
+    cd = PersistentContrastiveDivergence(
+        model=energy_function,
+        sampler=sampler,
+        k_steps=2,
+        buffer_size=20,
+        init_steps=2,
+        device=device,
+    )
+    x = torch.randn(5, 2, device=device)
+
+    loss, samples = cd(x)
+
+    assert cd.persistent is True
+    assert cd.buffer_initialized is True
+    assert cd.replay_buffer.shape == (20, 2)
+    assert loss.shape == torch.Size([])
+    assert samples.shape == x.shape
 
 
 def test_contrastive_divergence_forward(cd_loss):

--- a/tests/losses/test_public_api.py
+++ b/tests/losses/test_public_api.py
@@ -1,0 +1,31 @@
+import inspect
+
+import torch
+
+import torchebm.losses as losses
+from torchebm.core import GaussianModel
+from torchebm.samplers import LangevinDynamics
+
+
+def test_all_public_loss_classes_can_be_constructed():
+    model = GaussianModel(mean=torch.zeros(2), cov=torch.eye(2))
+    sampler = LangevinDynamics(model=model)
+    constructors = {
+        "ContrastiveDivergence": lambda: losses.ContrastiveDivergence(model, sampler),
+        "PersistentContrastiveDivergence": lambda: (
+            losses.PersistentContrastiveDivergence(model, sampler)
+        ),
+        "ScoreMatching": lambda: losses.ScoreMatching(model),
+        "DenoisingScoreMatching": lambda: losses.DenoisingScoreMatching(model),
+        "SlicedScoreMatching": lambda: losses.SlicedScoreMatching(model),
+        "EquilibriumMatchingLoss": lambda: losses.EquilibriumMatchingLoss(model),
+        "FlowMatchingLoss": lambda: losses.FlowMatchingLoss(model),
+        "EnergyMatchingLoss": lambda: losses.EnergyMatchingLoss(model),
+    }
+    public_classes = {
+        name for name in losses.__all__ if inspect.isclass(getattr(losses, name))
+    }
+
+    assert constructors.keys() == public_classes
+    for name, constructor in constructors.items():
+        assert type(constructor()).__name__ == name

--- a/tests/samplers/test_flow.py
+++ b/tests/samplers/test_flow.py
@@ -69,6 +69,21 @@ class TestFlowSampler:
         assert sampler.diffusion_form == "SBDM"
         assert sampler.diffusion_norm == 1.0
 
+    def test_repr(self, device, dtype):
+        sampler = FlowSampler(
+            MockModel(),
+            interpolant="linear",
+            prediction="velocity",
+            device=device,
+            dtype=dtype,
+        )
+        text = repr(sampler)
+        assert text.startswith("FlowSampler(")
+        assert "mode='ode'" in text
+        assert "interpolant=" in text
+        assert "prediction='velocity'" in text
+        assert "integrator=" in text
+
     def test_negate_velocity_conditions_model_on_zero_time(self, device, dtype):
         """EqM fields are time-invariant: trained on zeroed time, so sampling
         must condition the model on zeros too, not the integration clock."""

--- a/tests/samplers/test_flow.py
+++ b/tests/samplers/test_flow.py
@@ -80,9 +80,9 @@ class TestFlowSampler:
         text = repr(sampler)
         assert text.startswith("FlowSampler(")
         assert "mode='ode'" in text
-        assert "interpolant=" in text
+        assert "interpolant=LinearInterpolant" in text
         assert "prediction='velocity'" in text
-        assert "integrator=" in text
+        assert "integrator=Dopri5Integrator" in text
 
     def test_negate_velocity_conditions_model_on_zero_time(self, device, dtype):
         """EqM fields are time-invariant: trained on zeroed time, so sampling

--- a/tests/samplers/test_gradient_descent.py
+++ b/tests/samplers/test_gradient_descent.py
@@ -71,13 +71,28 @@ class TestGradientDescentSampler:
         assert_close(samples[0, 0], torch.tensor([0.9], device=device))
         assert_close(samples[0, 1], torch.tensor([0.81], device=device))
 
+    def test_repr(self, device, dtype):
+        model = QuadraticEnergy()
+        sampler = GradientDescentSampler(model, step_size=0.1, device=device, dtype=dtype)
+        text = repr(sampler)
+        assert text.startswith("GradientDescentSampler(")
+        assert "step_size=" in text
+
 class TestNesterovSampler:
-    
+
     def test_initialization(self, device, dtype):
         model = QuadraticEnergy()
         sampler = NesterovSampler(model, step_size=0.1, momentum=0.9, device=device, dtype=dtype)
         assert sampler.momentum == 0.9
-        
+
+    def test_repr(self, device, dtype):
+        model = QuadraticEnergy()
+        sampler = NesterovSampler(model, step_size=0.1, momentum=0.9, device=device, dtype=dtype)
+        text = repr(sampler)
+        assert text.startswith("NesterovSampler(")
+        assert "step_size=" in text
+        assert "momentum=0.9" in text
+
     def test_manual_step(self, device, dtype):
         # x_0 = 1.0, v_0 = 0.0
         # mu = 0.9, eta = 0.1

--- a/tests/samplers/test_gradient_descent.py
+++ b/tests/samplers/test_gradient_descent.py
@@ -76,7 +76,7 @@ class TestGradientDescentSampler:
         sampler = GradientDescentSampler(model, step_size=0.1, device=device, dtype=dtype)
         text = repr(sampler)
         assert text.startswith("GradientDescentSampler(")
-        assert "step_size=" in text
+        assert "step_size=0.1" in text
 
 class TestNesterovSampler:
 
@@ -90,7 +90,7 @@ class TestNesterovSampler:
         sampler = NesterovSampler(model, step_size=0.1, momentum=0.9, device=device, dtype=dtype)
         text = repr(sampler)
         assert text.startswith("NesterovSampler(")
-        assert "step_size=" in text
+        assert "step_size=0.1" in text
         assert "momentum=0.9" in text
 
     def test_manual_step(self, device, dtype):

--- a/tests/samplers/test_hmc.py
+++ b/tests/samplers/test_hmc.py
@@ -185,6 +185,30 @@ def test_hmc_initialization_with_mass():
     assert hmc_tensor.mass.device.type == device
 
 
+def test_hmc_repr(hmc_sampler):
+    text = repr(hmc_sampler)
+    assert text.startswith("HamiltonianMonteCarlo(")
+    assert "step_size=" in text
+    assert "n_leapfrog_steps=" in text
+    assert "mass=" in text
+    assert "integrator=" in text
+
+
+def test_hmc_repr_with_tensor_mass():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    energy_fn = GaussianModel(mean=torch.zeros(2), cov=torch.eye(2)).to(device)
+    tensor_mass = torch.tensor([2.0, 3.0], device=device)
+    sampler = HamiltonianMonteCarlo(
+        model=energy_fn,
+        step_size=0.1,
+        n_leapfrog_steps=10,
+        mass=tensor_mass,
+        device=device,
+    )
+    text = repr(sampler)
+    assert "mass=tensor(2,)" in text
+
+
 def test_hmc_initialization_invalid_params(energy_function):
     """Test that invalid parameters raise appropriate exceptions."""
     with pytest.raises(ValueError, match="step_size must be positive"):
@@ -965,6 +989,21 @@ def test_rmhmc_initialization():
     assert sampler.n_leapfrog_steps == 10
     # The default integrator should be the Generalised Leapfrog.
     assert type(sampler.integrator).__name__ == "GeneralisedLeapfrogIntegrator"
+
+
+def test_rmhmc_repr():
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = _gaussian_target(2, device)
+    sampler = RiemannianManifoldHMC(
+        model, metric_fn=_identity_metric(2),
+        step_size=0.1, n_leapfrog_steps=10, device=device,
+    )
+    text = repr(sampler)
+    assert text.startswith("RiemannianManifoldHMC(")
+    assert "metric_fn=" in text
+    assert "step_size=" in text
+    assert "n_leapfrog_steps=" in text
+    assert "integrator=" in text
 
 
 def test_rmhmc_initialization_invalid_metric_fn():

--- a/tests/samplers/test_hmc.py
+++ b/tests/samplers/test_hmc.py
@@ -188,10 +188,10 @@ def test_hmc_initialization_with_mass():
 def test_hmc_repr(hmc_sampler):
     text = repr(hmc_sampler)
     assert text.startswith("HamiltonianMonteCarlo(")
-    assert "step_size=" in text
-    assert "n_leapfrog_steps=" in text
-    assert "mass=" in text
-    assert "integrator=" in text
+    assert "step_size=0.1" in text
+    assert "n_leapfrog_steps=10" in text
+    assert "mass=None" in text
+    assert "integrator=LeapfrogIntegrator" in text
 
 
 def test_hmc_repr_with_tensor_mass():
@@ -1000,10 +1000,10 @@ def test_rmhmc_repr():
     )
     text = repr(sampler)
     assert text.startswith("RiemannianManifoldHMC(")
-    assert "metric_fn=" in text
-    assert "step_size=" in text
-    assert "n_leapfrog_steps=" in text
-    assert "integrator=" in text
+    assert "metric_fn=metric_fn" in text
+    assert "step_size=0.1" in text
+    assert "n_leapfrog_steps=10" in text
+    assert "integrator=GeneralisedLeapfrogIntegrator" in text
 
 
 def test_rmhmc_initialization_invalid_metric_fn():

--- a/tests/samplers/test_langevin_dynamics.py
+++ b/tests/samplers/test_langevin_dynamics.py
@@ -43,6 +43,14 @@ def test_langevin_dynamics_initialization(langevin_sampler):
     assert sampler.get_scheduled_value("noise_scale") == 1.0
 
 
+def test_langevin_dynamics_repr(langevin_sampler):
+    text = repr(langevin_sampler)
+    assert text.startswith("LangevinDynamics(")
+    assert "step_size=" in text
+    assert "noise_scale=" in text
+    assert "integrator=" in text
+
+
 def test_langevin_dynamics_initialization_invalid_params(energy_function):
     with pytest.raises(ValueError):
         LangevinDynamics(energy_function, step_size=-0.1, noise_scale=0.1)

--- a/tests/samplers/test_langevin_dynamics.py
+++ b/tests/samplers/test_langevin_dynamics.py
@@ -46,9 +46,9 @@ def test_langevin_dynamics_initialization(langevin_sampler):
 def test_langevin_dynamics_repr(langevin_sampler):
     text = repr(langevin_sampler)
     assert text.startswith("LangevinDynamics(")
-    assert "step_size=" in text
-    assert "noise_scale=" in text
-    assert "integrator=" in text
+    assert "step_size=0.005" in text
+    assert "noise_scale=1.0" in text
+    assert "integrator=EulerMaruyamaIntegrator" in text
 
 
 def test_langevin_dynamics_initialization_invalid_params(energy_function):

--- a/torchebm/core/base_integrator.py
+++ b/torchebm/core/base_integrator.py
@@ -91,6 +91,9 @@ class BaseIntegrator(TorchEBMModule, ABC):
         """
         raise NotImplementedError
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"
+
 
 class BaseRungeKuttaIntegrator(BaseIntegrator):
     r"""Abstract base class for explicit Runge-Kutta ODE integrators.
@@ -622,6 +625,15 @@ class BaseRungeKuttaIntegrator(BaseIntegrator):
         h = min(step_size.item(), t_end - t_start, self.max_step_size)
         x = self._adaptive_integrate(x, drift_fn, t_start, t_end, h)
         return {"x": x}
+
+    def __repr__(self) -> str:
+        if self.error_weights is not None:
+            return (
+                f"{self.__class__.__name__}("
+                f"atol={self.atol}, rtol={self.rtol}, "
+                f"max_steps={self.max_steps})"
+            )
+        return f"{self.__class__.__name__}()"
 
 
 class BaseSDERungeKuttaIntegrator(BaseRungeKuttaIntegrator):

--- a/torchebm/core/base_loss.py
+++ b/torchebm/core/base_loss.py
@@ -139,7 +139,9 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
         Runs on the first conditional call: the same one-sample input under
         two distinct in-batch y values (never fabricated labels, which could
         index outside an embedding), model temporarily in eval mode,
-        gradients off. Identical nonzero outputs on a fresh model raise.
+        gradients off. Every module's training flag is restored independently,
+        preserving intentionally mixed train/eval subtrees. Identical nonzero
+        outputs on a fresh model raise.
         Identical all-zero outputs are indeterminate, the signature of a
         zero-initialized output head: adaLN-Zero models emit exactly zero
         until trained, and their y-dependence surfaces only a few optimizer
@@ -178,14 +180,17 @@ class BaseLoss(Schedulable, TorchEBMModule, ABC):
             for k, v in model_kwargs.items()
             if k != "y"
         }
-        was_training = self.model.training
+        training_flags = {
+            module: module.training for module in self.model.modules()
+        }
         self.model.eval()
         try:
             with torch.no_grad():
                 out_a = self._probe_forward(px, {**pmk, "y": y[0:1]})
                 out_b = self._probe_forward(px, {**pmk, "y": y[i1 : i1 + 1]})
         finally:
-            self.model.train(was_training)
+            for module, training in training_flags.items():
+                module.training = training
         if isinstance(out_a, tuple):
             out_a = out_a[0]
         if isinstance(out_b, tuple):

--- a/torchebm/core/base_sampler.py
+++ b/torchebm/core/base_sampler.py
@@ -153,3 +153,6 @@ class BaseSampler(Schedulable, TorchEBMModule, ABC):
                 for samplers that cannot infer the state shape.
         """
         raise NotImplementedError
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(model={type(self.model).__name__})"

--- a/torchebm/integrators/leapfrog.py
+++ b/torchebm/integrators/leapfrog.py
@@ -491,3 +491,11 @@ class GeneralisedLeapfrogIntegrator(BaseSymplecticIntegrator):
             x, p = x_new, p_new
 
         return {"x": x, "p": p}
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"solver_max_iter={self.solver_max_iter}, "
+            f"solver_tol={self.solver_tol}, "
+            f"solver_check_every={self.solver_check_every})"
+        )

--- a/torchebm/losses/__init__.py
+++ b/torchebm/losses/__init__.py
@@ -6,7 +6,6 @@ __all__ = [
     # Contrastive Divergence
     "ContrastiveDivergence",
     "PersistentContrastiveDivergence",
-    "ParallelTemperingCD",
     # Score Matching
     "ScoreMatching",
     "DenoisingScoreMatching",
@@ -29,7 +28,6 @@ __all__ = [
 _LAZY_IMPORTS = {
     "ContrastiveDivergence": ".contrastive_divergence",
     "PersistentContrastiveDivergence": ".contrastive_divergence",
-    "ParallelTemperingCD": ".contrastive_divergence",
     "ScoreMatching": ".score_matching",
     "DenoisingScoreMatching": ".score_matching",
     "SlicedScoreMatching": ".score_matching",

--- a/torchebm/losses/contrastive_divergence.py
+++ b/torchebm/losses/contrastive_divergence.py
@@ -242,41 +242,9 @@ class ContrastiveDivergence(BaseContrastiveDivergence):
         return loss
 
 
-class PersistentContrastiveDivergence(BaseContrastiveDivergence):
-    def __init__(self, buffer_size=100):
-        super().__init__(k_steps=1)
-        self.buffer = None  # Persistent chain state
-        self.buffer_size = buffer_size
+class PersistentContrastiveDivergence(ContrastiveDivergence):
+    """Contrastive divergence with replay-buffer persistence enabled."""
 
-    # def sample(self, energy_model, x_pos):
-    #     if self.buffer is None or len(self.buffer) != self.buffer_size:
-    #         # Initialize buffer with random noise
-    #         self.buffer = torch.randn(self.buffer_size, *x_pos.batch_shape[1:],
-    #                                   device=x_pos.device)
-    #
-    #     # Update buffer with Gibbs steps
-    #     for _ in range(self.k_steps):
-    #         self.buffer = energy_model.gibbs_step(self.buffer)
-    #
-    #     # Return a subset of the buffer as negative samples
-    #     idx = torch.randint(0, self.buffer_size, (x_pos.batch_shape[0],))
-    #     return self.buffer[idx]
-
-
-class ParallelTemperingCD(BaseContrastiveDivergence):
-    def __init__(self, temps=[1.0, 0.5], k=5):
-        super().__init__(k)
-        self.temps = temps  # List of temperatures
-
-    # def sample(self, energy_model, x_pos):
-    #     chains = [x_pos.detach().clone() for _ in self.temps]
-    #     for _ in range(self.k_steps):
-    #         # Run Gibbs steps at each temperature
-    #         for i, temp in enumerate(self.temps):
-    #             chains[i] = energy_model.gibbs_step(chains[i], temp=temp)
-    #
-    #         # Swap states between chains (temperature exchange)
-    #         swap_idx = torch.randint(0, len(self.temps) - 1, (1,))
-    #         chains[swap_idx], chains[swap_idx + 1] = chains[swap_idx + 1], chains[swap_idx]
-    #
-    #     return chains[0]  # Return samples from the highest-temperature chain
+    def __init__(self, model, sampler, *args, **kwargs):
+        kwargs["persistent"] = True
+        super().__init__(model, sampler, *args, **kwargs)

--- a/torchebm/samplers/flow.py
+++ b/torchebm/samplers/flow.py
@@ -649,5 +649,15 @@ class FlowSampler(BaseSampler):
             - torch.sum(z.square(), dim=tuple(range(1, z.ndim))) / 2.0
         )
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"model={type(self.model).__name__}, "
+            f"mode={self.mode!r}, "
+            f"interpolant={type(self.interpolant).__name__}, "
+            f"prediction={self.prediction_type.name.lower()!r}, "
+            f"integrator={type(self.integrator).__name__})"
+        )
+
 
 __all__ = ["FlowSampler", "PredictionType"]

--- a/torchebm/samplers/gradient_descent.py
+++ b/torchebm/samplers/gradient_descent.py
@@ -141,6 +141,12 @@ class GradientDescentSampler(BaseSampler):
         output = trajectory if return_trajectory else x
         return (output, diagnostics) if return_diagnostics else output
 
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"model={type(self.model).__name__}, "
+            f"step_size={self.schedulers['step_size']!r})"
+        )
 
 
 class NesterovSampler(BaseSampler):
@@ -283,6 +289,14 @@ class NesterovSampler(BaseSampler):
 
         output = trajectory if return_trajectory else x
         return (output, diagnostics) if return_diagnostics else output
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"model={type(self.model).__name__}, "
+            f"step_size={self.schedulers['step_size']!r}, "
+            f"momentum={self.momentum})"
+        )
 
 
 __all__ = [

--- a/torchebm/samplers/gradient_descent.py
+++ b/torchebm/samplers/gradient_descent.py
@@ -145,7 +145,7 @@ class GradientDescentSampler(BaseSampler):
         return (
             f"{self.__class__.__name__}("
             f"model={type(self.model).__name__}, "
-            f"step_size={self.schedulers['step_size']!r})"
+            f"step_size={self.get_scheduled_value('step_size')})"
         )
 
 
@@ -294,7 +294,7 @@ class NesterovSampler(BaseSampler):
         return (
             f"{self.__class__.__name__}("
             f"model={type(self.model).__name__}, "
-            f"step_size={self.schedulers['step_size']!r}, "
+            f"step_size={self.get_scheduled_value('step_size')}, "
             f"momentum={self.momentum})"
         )
 

--- a/torchebm/samplers/hmc.py
+++ b/torchebm/samplers/hmc.py
@@ -340,6 +340,21 @@ class HamiltonianMonteCarlo(BaseSampler):
         output = trajectory if return_trajectory else x
         return (output, diagnostics) if return_diagnostics else output
 
+    def __repr__(self) -> str:
+        mass_repr = (
+            self.mass
+            if self.mass is None or isinstance(self.mass, float)
+            else f"tensor{tuple(self.mass.shape)}"
+        )
+        return (
+            f"{self.__class__.__name__}("
+            f"model={type(self.model).__name__}, "
+            f"step_size={self.schedulers['step_size']!r}, "
+            f"n_leapfrog_steps={self.n_leapfrog_steps}, "
+            f"mass={mass_repr}, "
+            f"integrator={type(self.integrator).__name__})"
+        )
+
 
 class RiemannianManifoldHMC(BaseSampler):
     r"""
@@ -758,3 +773,13 @@ class RiemannianManifoldHMC(BaseSampler):
 
         output = trajectory if return_trajectory else x
         return (output, diagnostics) if return_diagnostics else output
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"model={type(self.model).__name__}, "
+            f"metric_fn={self.metric_fn!r}, "
+            f"step_size={self.schedulers['step_size']!r}, "
+            f"n_leapfrog_steps={self.n_leapfrog_steps}, "
+            f"integrator={type(self.integrator).__name__})"
+        )

--- a/torchebm/samplers/hmc.py
+++ b/torchebm/samplers/hmc.py
@@ -349,7 +349,7 @@ class HamiltonianMonteCarlo(BaseSampler):
         return (
             f"{self.__class__.__name__}("
             f"model={type(self.model).__name__}, "
-            f"step_size={self.schedulers['step_size']!r}, "
+            f"step_size={self.get_scheduled_value('step_size')}, "
             f"n_leapfrog_steps={self.n_leapfrog_steps}, "
             f"mass={mass_repr}, "
             f"integrator={type(self.integrator).__name__})"
@@ -775,11 +775,14 @@ class RiemannianManifoldHMC(BaseSampler):
         return (output, diagnostics) if return_diagnostics else output
 
     def __repr__(self) -> str:
+        metric_fn_name = getattr(
+            self.metric_fn, "__name__", type(self.metric_fn).__name__
+        )
         return (
             f"{self.__class__.__name__}("
             f"model={type(self.model).__name__}, "
-            f"metric_fn={self.metric_fn!r}, "
-            f"step_size={self.schedulers['step_size']!r}, "
+            f"metric_fn={metric_fn_name}, "
+            f"step_size={self.get_scheduled_value('step_size')}, "
             f"n_leapfrog_steps={self.n_leapfrog_steps}, "
             f"integrator={type(self.integrator).__name__})"
         )

--- a/torchebm/samplers/langevin_dynamics.py
+++ b/torchebm/samplers/langevin_dynamics.py
@@ -191,3 +191,12 @@ class LangevinDynamics(BaseSampler):
 
         output = trajectory if return_trajectory else x
         return (output, diagnostics) if return_diagnostics else output
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"model={type(self.model).__name__}, "
+            f"step_size={self.schedulers['step_size']!r}, "
+            f"noise_scale={self.schedulers['noise_scale']!r}, "
+            f"integrator={type(self.integrator).__name__})"
+        )

--- a/torchebm/samplers/langevin_dynamics.py
+++ b/torchebm/samplers/langevin_dynamics.py
@@ -196,7 +196,7 @@ class LangevinDynamics(BaseSampler):
         return (
             f"{self.__class__.__name__}("
             f"model={type(self.model).__name__}, "
-            f"step_size={self.schedulers['step_size']!r}, "
-            f"noise_scale={self.schedulers['noise_scale']!r}, "
+            f"step_size={self.get_scheduled_value('step_size')}, "
+            f"noise_scale={self.get_scheduled_value('noise_scale')}, "
             f"integrator={type(self.integrator).__name__})"
         )


### PR DESCRIPTION
Reprs for samplers and integrators, a working PersistentContrastiveDivergence, removal of the unusable ParallelTemperingCD, probe cleanup coverage, and the contribution rules reviews had been repeating by hand.

resolves #191
resolves #321
resolves #322